### PR TITLE
Support multiple replacements

### DIFF
--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -83,6 +83,44 @@ func TestReplace(t *testing.T) {
 	}
 }
 
+func TestMultiReplace(t *testing.T) {
+	var tests = []struct {
+		testName     string
+		in           string
+		out          string
+		replacements map[string]string
+	}{
+		{
+			testName: "simple test",
+			in:       "http://automattic.com",
+			out:      "https://automattic.org",
+			replacements: map[string]string{
+				"http:":          "https:",
+				"automattic.com": "automattic.org",
+			},
+		},
+		{
+			testName: "overlapping",
+			in:       "http://automattic.com",
+			out:      "https://automattic.org",
+			replacements: map[string]string{
+				"http:":            "https:",
+				"//automattic.com": "//automattic.org",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			replaced := replaceAndFix(test.in, test.replacements)
+
+			if replaced != test.out {
+				t.Error("Expected:", test.out, "Actual:", replaced)
+			}
+		})
+	}
+}
+
 func TestFix(t *testing.T) {
 	var tests = []struct {
 		testName string

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -16,7 +16,9 @@ func BenchmarkSimpleReplace(b *testing.B) {
 	from := "http:"
 	to := "https:"
 	for i := 0; i < b.N; i++ {
-		replaceAndFix(line, from, to)
+		replaceAndFix(line, map[string]string{
+			from: to,
+		})
 	}
 }
 
@@ -25,7 +27,9 @@ func BenchmarkSerializedReplace(b *testing.B) {
 	from := "http://automattic.com"
 	to := "https://automattic.com"
 	for i := 0; i < b.N; i++ {
-		replaceAndFix(line, from, to)
+		replaceAndFix(line, map[string]string{
+			from: to,
+		})
 	}
 }
 
@@ -68,7 +72,10 @@ func TestReplace(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			replaced := replaceAndFix(test.in, test.from, test.to)
+			replaced := replaceAndFix(test.in, map[string]string{
+				test.from: test.to,
+			})
+
 			if replaced != test.out {
 				t.Error("Expected:", test.out, "Actual:", replaced)
 			}


### PR DESCRIPTION
* Takes multiple sets of replacements
* Loops over replacements for each line

I was going to do all the string replacements and fix serialized strings
at the end, but the efficiency of the fixer function makes it moot
because we skip serialized strings that we didn't touch. Combined with
the slow performance of appending to a slice, it's actually faster like
this.

Fixes #11