### PR TITLE
Add Apple M1 Build Arch (& other arm64)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-    - 1.13.x
+    - 1.16.x
     - master
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ all: vet fmt lint test build
 
 build: clean
 	which gox > /dev/null || go get -u github.com/mitchellh/gox
-	gox -os="linux" -os="darwin" -os="windows" -arch="amd64" -arch="386" -arch="arm64" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
+	gox -os="linux" -os="windows" -arch="amd64" -arch="386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
+	gox -os="darwin" -arch="amd64" -arch="arm64" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
 	gzip build/*
 
 vet:

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ all: vet fmt lint test build
 
 build: clean
 	which gox > /dev/null || go get -u github.com/mitchellh/gox
-	gox -os="linux" -os="windows" -arch="amd64" -arch="arm64" -arch="386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
-	gox -os="darwin" -arch="amd64" -arch="arm64" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
+	gox -os="darwin" -os="linux" -os="windows" -arch="amd64" -arch="arm64" -osarch="linux/386" -osarch="windows/386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
 	gzip build/*
 
 vet:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: vet fmt lint test build
 
 build: clean
 	which gox > /dev/null || go get -u github.com/mitchellh/gox
-	gox -os="linux" -os="darwin" -os="windows" -arch="amd64" -arch="386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
+	gox -os="linux" -os="darwin" -os="windows" -arch="amd64" -arch="386" -arch="arm64" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
 	gzip build/*
 
 vet:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: vet fmt lint test build
 
 build: clean
 	which gox > /dev/null || go get -u github.com/mitchellh/gox
-	gox -os="linux" -os="windows" -arch="amd64" -arch="386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
+	gox -os="linux" -os="windows" -arch="amd64" -arch="arm64" -arch="386" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
 	gox -os="darwin" -arch="amd64" -arch="arm64" -output="${BUILDDIR}/${BINARY}_{{.OS}}_{{.Arch}}"
 	gzip build/*
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/automattic/go-search-replace
+
+go 1.16

--- a/search-replace.go
+++ b/search-replace.go
@@ -32,6 +32,7 @@ var (
 	bad     = regexp.MustCompile(badInputRe)
 )
 
+// Replacement has two fields (both byte slices): "From" & "To"
 type Replacement struct {
 	From []byte
 	To   []byte

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -18,7 +18,7 @@ func BenchmarkSimpleReplace(b *testing.B) {
 	to := []byte("https:")
 	for i := 0; i < b.N; i++ {
 		replaceAndFix(&line, []*Replacement{
-			&Replacement{
+			{
 				From: from,
 				To:   to,
 			},
@@ -32,7 +32,7 @@ func BenchmarkSerializedReplace(b *testing.B) {
 	to := []byte("https://automattic.com")
 	for i := 0; i < b.N; i++ {
 		replaceAndFix(&line, []*Replacement{
-			&Replacement{
+			{
 				From: from,
 				To:   to,
 			},
@@ -98,7 +98,7 @@ func TestReplace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			replaced := replaceAndFix(&test.in, []*Replacement{
-				&Replacement{
+				{
 					From: test.from,
 					To:   test.to,
 				},
@@ -123,11 +123,11 @@ func TestMultiReplace(t *testing.T) {
 			in:       []byte("http://automattic.com"),
 			out:      []byte("https://automattic.org"),
 			replacements: []*Replacement{
-				&Replacement{
+				{
 					From: []byte("http:"),
 					To:   []byte("https:"),
 				},
-				&Replacement{
+				{
 					From: []byte("automattic.com"),
 					To:   []byte("automattic.org"),
 				},
@@ -138,11 +138,11 @@ func TestMultiReplace(t *testing.T) {
 			in:       []byte("http://automattic.com"),
 			out:      []byte("https://automattic.org"),
 			replacements: []*Replacement{
-				&Replacement{
+				{
 					From: []byte("http:"),
 					To:   []byte("https:"),
 				},
-				&Replacement{
+				{
 					From: []byte("//automattic.com"),
 					To:   []byte("//automattic.org"),
 				},


### PR DESCRIPTION
Now that go 1.16 [has dropped](https://golang.org/doc/go1.16), we can add darwin/arm64 to our build targets.

This change:

* Bumps the go version to `1.16.x` in the Travis CI config
* Splits out the `darwin` platform into its own `gox` call (`darwin/386` is not a valid `GOOS`/`GOARCH` pair)
* Adds a barebones go.mod file (to get past `cannot find main module` error in `go vet`)
* Adds a comment to the `Replacement` struct (to satisfy the `lint` job)
* Runs the test file through `gofmt -s` (to satisfy the `fmt` job)

## Discussion

https://a8c.slack.com/archives/CKUJZT08Y/p1614186371037300?thread_ts=1614128274.023800&cid=CKUJZT08Y

## To Test

* Install go 1.16
* Clone this repo
* `make`
    * The build should complete without error
    * `ls build` should contain valid gzipped binaries for all supported platform / architecture pairs.

### Test on an M1 Mac

* `curl -L -o - https://github.com/Automattic/go-search-replace/releases/download/0.0.6-pre/go-search-replace_darwin_arm64.gz | gunzip > /tmp/go-search-replace`
* `chmod +x /tmp/go-search-replace`
* `echo "You can do anything at https://zombo.com" | /tmp/go-search-replace "zombo.com" "wpvip.com"`
    * Should print:
      > You can do anything at https://wpvip.com

Fixes #27 