### PR TITLE
Don't ignore last line with no trailing newline

### DIFF
--- a/search-replace.go
+++ b/search-replace.go
@@ -97,10 +97,10 @@ func main() {
 			line, err := r.ReadBytes('\n')
 
 			if err == io.EOF {
-				break
-			}
-
-			if err != nil {
+				if 0 == len(line) {
+					break
+				}
+			} else if err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 				break
 			}


### PR DESCRIPTION
### Problem

If the final (or only) line of the input does not contain a trailing newline, the line is dropped from the output:

```sh
$ printf "from" | ./go-search-replace from to
```

```sh
$ printf "from\nfrom" | ./go-search-replace from to
to
```

This is happening because code in `main()` checks for `io.EOF` and `break`s without first checking if `line` is empty.

### Fix

Add some logic to only `break` if we have reached the end of the stream _and_ the `line` is empty.

I'm new to Golang so I'm not sure how to add a test for this. The problem is in `main()` so it probably requires a refactor and an abstraction around the stdin stream. Happy to pair. 👋 