### PR TITLE
Correctly handle lengths of serialized strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test:
 	go test -v ./...
 	go test -bench .
 
+bench:
+	go test -bench .
+
 clean:
 	rm -rf ${BUILDDIR}
 

--- a/main_test.go
+++ b/main_test.go
@@ -84,3 +84,25 @@ func TestMultipleReplaceWithoutNewlineAtEOF(t *testing.T) {
 	expected := "Space, the final frontier!\nCheck out: warp://ncc-1701-d.space/decks/10/areas/forward"
 	doMainTest(t, input, expected, mainArgs)
 }
+
+func TestSerializedReplaceWithCss(t *testing.T) {
+	mainArgs := []string{
+		"https://uss-enterprise.com",
+		"https://ncc-1701-d.space",
+	}
+
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:216:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:214:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	doMainTest(t, input, expected, mainArgs)
+}
+
+func TestSerializedReplaceWithCssAndUnrelatedSerializationMarker(t *testing.T) {
+	mainArgs := []string{
+		"https://uss-enterprise.com",
+		"https://ncc-1701-d.space",
+	}
+
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:249:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:247:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	doMainTest(t, input, expected, mainArgs)
+}

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -81,7 +81,7 @@ func TestReplace(t *testing.T) {
 			from: []byte("http://🖖.com"),
 			to:   []byte("https://spock.com"),
 
-			in:  []byte(`s:12:\"http://🖖.com\";`),
+			in:  []byte(`s:15:\"http://🖖.com\";`),
 			out: []byte(`s:17:\"https://spock.com\";`),
 		},
 		{
@@ -92,6 +92,24 @@ func TestReplace(t *testing.T) {
 
 			in:  []byte(`s:17:\"https://spock.com\";`),
 			out: []byte(`s:15:\"http://🖖.com\";`),
+		},
+		{
+			testName: "search and replace with different lengths",
+
+			from: []byte("hello"),
+			to:   []byte("goodbye"),
+
+			in:  []byte(`s:11:\"hello-world\";`),
+			out: []byte(`s:13:\"goodbye-world\";`),
+		},
+		{
+			testName: "search and replace with different lengths",
+
+			from: []byte("bbbbbbbbbb"),
+			to:   []byte("ccccccccccccccc"),
+
+			in:  []byte(`s:20:\"aaaaabbbbbbbbbbaaaaa\";`),
+			out: []byte(`s:25:\"aaaaacccccccccccccccaaaaa\";`),
 		},
 	}
 

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -12,7 +12,35 @@ func BenchmarkFix(b *testing.B) {
 	}
 }
 
-func BenchmarkSimpleReplace(b *testing.B) {
+func BenchmarkNoReplaceOld(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("bananas")
+	to := []byte("apples")
+	for i := 0; i < b.N; i++ {
+		replaceAndFix(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkNoReplaceNew(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("bananas")
+	to := []byte("apples")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSimpleReplaceOld(b *testing.B) {
 	line := []byte("http://automattic.com")
 	from := []byte("http:")
 	to := []byte("https:")
@@ -26,12 +54,40 @@ func BenchmarkSimpleReplace(b *testing.B) {
 	}
 }
 
-func BenchmarkSerializedReplace(b *testing.B) {
+func BenchmarkSimpleReplaceNew(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("http:")
+	to := []byte("https:")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSerializedReplaceOld(b *testing.B) {
 	line := []byte(`s:0:\"http://automattic.com\";`)
 	from := []byte("http://automattic.com")
 	to := []byte("https://automattic.com")
 	for i := 0; i < b.N; i++ {
 		replaceAndFix(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSerializedReplaceNew(b *testing.B) {
+	line := []byte(`s:0:\"http://automattic.com\";`)
+	from := []byte("http://automattic.com")
+	to := []byte("https://automattic.com")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
 			{
 				From: from,
 				To:   to,
@@ -115,7 +171,7 @@ func TestReplace(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			replaced := replaceAndFix(&test.in, []*Replacement{
+			replaced := fixLine(&test.in, []*Replacement{
 				{
 					From: test.from,
 					To:   test.to,


### PR DESCRIPTION
This introduces an alternate approach to handling serialized strings. 

Previously, we were running a search-replace per line and then attempting to fix the lengths of any serialized strings we found. This could be problematic in various contexts including when the serialized string contains an closing string delimiter (see #33).

In this PR, we handle each serialized string chunk separately by extracting the string based on the serialized string length and then running search-replace within that chunk, updating the length, and then replacing in place.

The approach is slower but addresses several bugs and edge cases.

Next:
- [ ] Clean up the PR (remove debug statements)
- [ ] Handle edge cases like out-of-boundary errors
- [ ] Test, benchmark, and share the changes
- [ ] Package and ship