### PR TITLE
Reimagined: Correctly handle lengths of serialized strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test:
 	go test -v ./...
 	go test -bench .
 
+bench:
+	go test -bench .
+
 clean:
 	rm -rf ${BUILDDIR}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Automattic/go-search-replace
 
-go 1.16
+go 1.23.2

--- a/main_test.go
+++ b/main_test.go
@@ -84,3 +84,25 @@ func TestMultipleReplaceWithoutNewlineAtEOF(t *testing.T) {
 	expected := "Space, the final frontier!\nCheck out: warp://ncc-1701-d.space/decks/10/areas/forward"
 	doMainTest(t, input, expected, mainArgs)
 }
+
+func TestSerializedReplaceWithCss(t *testing.T) {
+	mainArgs := []string{
+		"https://uss-enterprise.com",
+		"https://ncc-1701-d.space",
+	}
+
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:216:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:214:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	doMainTest(t, input, expected, mainArgs)
+}
+
+func TestSerializedReplaceWithCssAndUnrelatedSerializationMarker(t *testing.T) {
+	mainArgs := []string{
+		"https://uss-enterprise.com",
+		"https://ncc-1701-d.space",
+	}
+
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:249:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:247:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	doMainTest(t, input, expected, mainArgs)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -96,6 +96,18 @@ func TestSerializedReplaceWithCss(t *testing.T) {
 	doMainTest(t, input, expected, mainArgs)
 }
 
+func TestComplexSerializedReplace(t *testing.T) {
+	mainArgs := []string{
+		`http:\\/\\/example\\.com`,
+		`http:\\/\\/example2\\.com`,
+	}
+
+	input := `s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";`
+	expected := `s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`
+
+	doMainTest(t, input, expected, mainArgs)
+}
+
 func TestSerializedReplaceWithCssAndUnrelatedSerializationMarker(t *testing.T) {
 	mainArgs := []string{
 		"https://uss-enterprise.com",

--- a/main_test.go
+++ b/main_test.go
@@ -91,20 +91,8 @@ func TestSerializedReplaceWithCss(t *testing.T) {
 		"https://ncc-1701-d.space",
 	}
 
-	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:216:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
-	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:214:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
-	doMainTest(t, input, expected, mainArgs)
-}
-
-func TestComplexSerializedReplace(t *testing.T) {
-	mainArgs := []string{
-		`http:\\/\\/example\\.com`,
-		`http:\\/\\/example2\\.com`,
-	}
-
-	input := `s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";`
-	expected := `s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`
-
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:208:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:206:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
 	doMainTest(t, input, expected, mainArgs)
 }
 
@@ -114,7 +102,7 @@ func TestSerializedReplaceWithCssAndUnrelatedSerializationMarker(t *testing.T) {
 		"https://ncc-1701-d.space",
 	}
 
-	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:249:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
-	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:247:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	input := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:239:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
+	expected := `a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:237:\"body { color: #123456;\r\nborder-bottom: none; }\r\nbody:after{ content: \"▼\"; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`
 	doMainTest(t, input, expected, mainArgs)
 }

--- a/search-replace.go
+++ b/search-replace.go
@@ -182,8 +182,8 @@ var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):\\"`)
 func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*SerializedReplaceResult, error) {
 
 	// find starting point in the line
-	//TODO: We should first check if we found the string when inside a quote or not.
-	// but currently skipping that scenario because it seems unlikely to find it outside.
+	// We're not checking if we found the serialized string prefix inside a quote or not.
+	// Currently skipping that scenario because it seems unlikely to find it outside.
 	match := serializedStringPrefixRegexp.FindSubmatchIndex(linePart)
 	if match == nil {
 		return &SerializedReplaceResult{

--- a/search-replace.go
+++ b/search-replace.go
@@ -214,7 +214,7 @@ func replaceInSerializedBytes(serialized []byte, replacements []*Replacement) []
 	return serialized
 }
 
-var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):`)
+var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):\\"`)
 
 // Parses escaped data, returning the location details for further parsing
 func parseEscapedData(linePart []byte) (*EscapedDataDetails, error) {

--- a/search-replace.go
+++ b/search-replace.go
@@ -135,18 +135,7 @@ func main() {
 	}
 }
 
-var debugMode = false
-
-func Debugf(format string, args ...interface{}) {
-	if debugMode {
-		fmt.Printf(format, args...)
-	}
-}
-
 func fixLine(line *[]byte, replacements []*Replacement) *[]byte {
-
-	Debugf("Doing global replacements: %s\n", string(*line))
-
 	linePart := *line
 
 	var rebuiltLine []byte
@@ -154,7 +143,6 @@ func fixLine(line *[]byte, replacements []*Replacement) *[]byte {
 	for len(linePart) > 0 {
 		result, err := fixLineWithSerializedData(linePart, replacements)
 		if err != nil {
-			Debugf("Error when trying to fix line : %s\n", err.Error())
 			rebuiltLine = append(rebuiltLine, linePart...)
 			break
 		}
@@ -164,8 +152,6 @@ func fixLine(line *[]byte, replacements []*Replacement) *[]byte {
 	}
 
 	*line = rebuiltLine
-
-	Debugf("All done: %s\n", string(*line))
 
 	return line
 }

--- a/search-replace.go
+++ b/search-replace.go
@@ -280,7 +280,7 @@ func fixSerializedContent(line *[]byte, replacements []*Replacement) *Serialized
 
 		rebuiltLine = append(rebuiltLine, []byte(rebuilt)...)
 		serializedContentRange = append(serializedContentRange, SerializedContentRange{
-			From: index,
+			From: index + details.CurrentPartIndex,
 			To:   index + len(rebuilt) - 1,
 		})
 

--- a/search-replace.go
+++ b/search-replace.go
@@ -38,34 +38,10 @@ type Replacement struct {
 	To   []byte
 }
 
-type EscapedDataDetails struct {
-	ContentStartIndex   int
-	ContentEndIndex     int
-	NextPartIndex       int
-	CurrentPartIndex    int
-	OriginalByteSize    int
-	SerializedPartRange SerializedPartRange
-}
-
-type SerializedPartRange struct {
-	From int
-	To   int
-}
-
 type SerializedReplaceResult struct {
 	Pre               []byte
 	SerializedPortion []byte
 	Post              []byte
-}
-
-type SerializedContentReplacement struct {
-	FixedContent           []byte
-	SerializedContentRange []SerializedPartRange
-}
-
-type LinePartWithType struct {
-	Content       []byte
-	PhpSerialized bool
 }
 
 func main() {

--- a/search-replace.go
+++ b/search-replace.go
@@ -206,7 +206,8 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 	originalByteSize, _ := strconv.Atoi(string(originalBytes))
 
 	// the following assumes escaped double quotes
-	//TODO: MySQL can optionally not escape the double quote,
+	// i.e. s:5:\"x -> we'll need to shift our index from '5' to 'x' - hence shifting by 3
+	// MySQL can optionally not escape the double quote,
 	// but generally sqldumps always include the quotes.
 	contentStartIndex := match[3] + 3
 

--- a/search-replace.go
+++ b/search-replace.go
@@ -316,12 +316,8 @@ func getUnescapedBytesIfEscaped(charPair []byte) []byte {
 
 	backslash := byte('\\')
 
-	//escapables := []byte{'\\', '\'', '"', 'n', 'r', 't', 'b', 'f', '0'}
-
-	// a map of the second byte to its actual binary presentation
-
-	// if the first byte is not a backslash, we don't need to do anything
-
+	// if the first byte is not a backslash, we don't need to do anything - we'll return the bytes
+	// as per the function name, we'll return both bytes, or return one byte if one byte is actually an escape character
 	if charPair[0] != backslash {
 		return charPair
 	}

--- a/search-replace.go
+++ b/search-replace.go
@@ -352,18 +352,10 @@ func unescapeContent(escaped []byte) []byte {
 	unescapedBytes := make([]byte, 0, len(escaped))
 	index := 0
 
-	// only applies to content - do not apply to raw mysql query
+	// only applies to content of a string - do not apply to raw mysql query
 	// tested with php -i, mysql client, and mysqldump and mydumper.
-	// 1. \" in dump becomes " when inserting a mysql row.
-	// 2. \\ in dump becomes \ when inserting a mysql row.
-	// 3. \' in dump becomes ' when inserting a mysql row.
-	// 4. mysql translates newline into \n when creating a mysqldump. Same applies to carriage return.
-	// 5. PHP serialize does not convert the bytes \r or \n into something else - they're as-is.
-	// 6. If using single quotes in php, \r and \n does not get converted into bytes - they become literal backslash and letter.
-	// Generally, to unescape, we need to do the following:
-	// 1. Convert \\ to \
-	// 2. Convert \' to '
-	// 3. Convert \" to "
+	// 1. mysql translates certain bytes to `\<char>` i.e. `\n`. So these needs unescaping to get the correct byte length. See `getUnescapedBytesIfEscaped`
+	// 2. PHP serialize does not convert raw bytes into `\<char>` - they're as-is, so we don't need to take into account of escaped value in byte length calculation.
 
 	backslash := byte('\\')
 

--- a/search-replace.go
+++ b/search-replace.go
@@ -38,6 +38,14 @@ type Replacement struct {
 	To   []byte
 }
 
+type EscapedDataDetails struct {
+	ContentStartIndex int
+	ContentEndIndex   int
+	NextPartIndex     int
+	CurrentPartIndex  int
+	OriginalByteSize  int
+}
+
 func main() {
 	versionFlag := flag.Bool("version", false, "Show version information")
 	flag.Parse()
@@ -132,7 +140,6 @@ func main() {
 var debugMode = false
 
 func Debugf(format string, args ...interface{}) {
-	return
 	if debugMode {
 		fmt.Printf(format, args...)
 	}
@@ -155,64 +162,46 @@ func fixLine(line *[]byte, replacements []*Replacement) *[]byte {
 	return line
 }
 
-var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):\\"`)
-
 func fixSerializedContent(line *[]byte, replacements []*Replacement) *[]byte {
-	startIndex := 0
-	for startIndex < len(*line) {
-		Debugf("Start of loop, startIndex: %d\n", startIndex)
-		match := serializedStringPrefixRegexp.FindSubmatchIndex((*line)[startIndex:])
-		if match == nil {
+	index := 0
+
+	var rebuiltLine []byte
+
+	for index < len(*line) {
+		Debugf("Start of loop, index: %d\n", index)
+		linePart := (*line)[index:]
+
+		details, err := parseEscapedData(linePart)
+
+		if err != nil {
+			// we've run out of things to parse, so just break out and append the rest
+			rebuiltLine = append(rebuiltLine, linePart...)
 			break
 		}
 
-		length, err := strconv.Atoi(string((*line)[startIndex+match[2] : startIndex+match[3]]))
-		if err != nil {
-			startIndex++
-			continue
-		}
-		Debugf("Match found, length: %d\n", length)
+		rebuiltLine = append(rebuiltLine, (*line)[index:index+details.CurrentPartIndex]...)
 
-		contentStart := startIndex + match[1]
-		contentEnd := contentStart + length
+		index = index + details.NextPartIndex
 
-		// TODO: check if the next three letters are \"; to catch broken serialized content. If not, skip this section.
+		content := linePart[details.ContentStartIndex : details.ContentEndIndex+1]
 
-		Debugf("Content boundaries, start: %d, end: %d\n", contentStart, contentEnd)
+		updatedContent := replaceInSerializedBytes(content, replacements)
 
-		serializedContent := (*line)[contentStart:contentEnd]
-		Debugf("Content before: %s\n", serializedContent)
-		updatedContent := replaceInSerializedBytes(serializedContent, replacements)
-		Debugf("Content after: %s\n\n", updatedContent)
+		// php needs the unescaped length, so let's unescape it and measure the length
+		contentLength := len(unescapeContent(updatedContent))
 
-		// no change, move to the next one
-		if bytes.Equal(serializedContent, updatedContent) {
-			startIndex = contentEnd + len(`\";`)
-			Debugf("No replacements made; skipping to %d: %s\n", startIndex, updatedContent)
-			// TODO: fix
-			continue
+		// but if the content never changed, we'll let the error be for safety.
+		if bytes.Equal(content, updatedContent) {
+			contentLength = details.OriginalByteSize
 		}
 
-		// Calculate the new length and update the serialized length prefix
-		newLength := len(updatedContent)
-		newLengthStr := []byte(strconv.Itoa(newLength))
-		Debugf("Replaced content new length: %d\n", newLength)
-		*line = append((*line)[:startIndex+match[2]], append(newLengthStr, (*line)[startIndex+match[3]:]...)...)
-		Debugf("After updating length prefix: %s\n", string(*line))
+		// and we rebuild the string
+		rebuilt := "s:" + strconv.Itoa(contentLength) + ":\\\"" + string(updatedContent) + "\\\";"
 
-		// Update the serialized content inline
-
-		//contentEnd = contentStart + newLength // adjust the end index based on the new length -- THIS BREAKS THINGS
-
-		*line = append((*line)[:contentStart], append(updatedContent, (*line)[contentEnd:]...)...)
-		Debugf("After updating content: %s\n", string(*line))
-
-		// Adjust startIndex for the next iteration
-		startIndex += match[1] + newLength + len(newLengthStr) - len((*line)[startIndex+match[2]:startIndex+match[3]])
-		Debugf("New startIndex: %d\n", startIndex)
+		rebuiltLine = append(rebuiltLine, []byte(rebuilt)...)
 	}
 
-	return line
+	return &rebuiltLine
 }
 
 func replaceInSerializedBytes(serialized []byte, replacements []*Replacement) []byte {
@@ -220,6 +209,184 @@ func replaceInSerializedBytes(serialized []byte, replacements []*Replacement) []
 		serialized = bytes.ReplaceAll(serialized, replacement.From, replacement.To)
 	}
 	return serialized
+}
+
+var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):`)
+
+// Parses escaped data, returning the location details for further parsing
+func parseEscapedData(linePart []byte) (*EscapedDataDetails, error) {
+
+	details := EscapedDataDetails{
+		ContentStartIndex: 0,
+		ContentEndIndex:   0,
+		NextPartIndex:     0,
+		CurrentPartIndex:  0,
+		OriginalByteSize:  0,
+	}
+
+	// find starting point in the line
+	//TODO: We should first check if we found the string when inside a quote or not.
+	// but currently skipping that scenario because it seems unlikely to find it outside.
+	match := serializedStringPrefixRegexp.FindSubmatchIndex(linePart)
+	if match == nil {
+		return nil, fmt.Errorf("could not find serialized string prefix")
+	}
+
+	matchedAt := match[0]
+	originalBytes := linePart[match[2]:match[3]]
+
+	details.OriginalByteSize, _ = strconv.Atoi(string(originalBytes))
+
+	details.CurrentPartIndex = matchedAt
+
+	// the following assumes escaped double quotes
+	//TODO: MySQL can optionally not escape the double quote,
+	// but generally sqldumps always include the quotes.
+	initialContentIndex := match[3] + 3
+
+	details.ContentStartIndex = initialContentIndex
+
+	currentContentIndex := initialContentIndex
+
+	contentByteCount := 0
+
+	var nextPartIndex int
+
+	backslash := byte('\\')
+	semicolon := byte(';')
+	quote := byte('"')
+	nextPartFound := false
+
+	secondMatch := serializedStringPrefixRegexp.FindSubmatchIndex(linePart[matchedAt+1:])
+
+	maxIndex := len(linePart)
+
+	if secondMatch != nil {
+		maxIndex = secondMatch[0]
+	}
+
+	// let's find where the content actually ends.
+	// it should end when the unescaped value is `";`
+	for currentContentIndex < len(linePart) {
+		if currentContentIndex+2 >= maxIndex {
+
+			// if we have a second match, we can at least
+			if secondMatch != nil {
+
+			}
+
+			// this algorithm SHOULD work, but in cases where the original byte count does not match
+			// the actual byte count, it'll error out. We'll add this safeguard here.
+			return nil, fmt.Errorf("faulty data, byte count does not match data size")
+		}
+		char := linePart[currentContentIndex]
+		secondChar := linePart[currentContentIndex+1]
+		thirdChar := linePart[currentContentIndex+2]
+		if char == backslash && contentByteCount < details.OriginalByteSize {
+			unescapedBytePair := getUnescapedBytesIfEscaped(linePart[currentContentIndex : currentContentIndex+2])
+			// if we get the byte pair without the backslash, it corresponds to a byte
+			contentByteCount += len(unescapedBytePair)
+
+			// content index count remains the same.
+			currentContentIndex += 2
+			continue
+		}
+
+		if char == backslash && secondChar == quote && thirdChar == semicolon && contentByteCount >= details.OriginalByteSize {
+
+			// since we've filtered out all the escaped value already, this should be the actual end
+			nextPartIndex = currentContentIndex + 3
+			details.NextPartIndex = nextPartIndex
+			// we're at backslash, so we need to minus 1 to get the index where the content finishes
+			details.ContentEndIndex = currentContentIndex - 1
+			nextPartFound = true
+			break
+		}
+
+		contentByteCount++
+		currentContentIndex++
+	}
+
+	if nextPartFound == false {
+		return nil, fmt.Errorf("end of serialized string not found")
+	}
+
+	return &details, nil
+}
+
+func getUnescapedBytesIfEscaped(charPair []byte) []byte {
+
+	backslash := byte('\\')
+
+	//escapables := []byte{'\\', '\'', '"', 'n', 'r', 't', 'b', 'f', '0'}
+
+	// a map of the second byte to its actual binary presentation
+
+	// if the first byte is not a backslash, we don't need to do anything
+
+	if charPair[0] != backslash {
+		return charPair
+	}
+
+	unescapedMap := map[byte]byte{
+		'\\': '\\',
+		'\'': '\'',
+		'"':  '"',
+		'n':  '\n',
+		'r':  '\r',
+		't':  '\t',
+		'b':  '\b',
+		'f':  '\f',
+		'0':  '\x00',
+	}
+
+	actualByte := unescapedMap[charPair[1]]
+
+	if actualByte != 0 {
+		return []byte{actualByte}
+	}
+
+	// what if it's not a valid escape? Do nothing - it's considered as already escaped
+	return charPair
+}
+
+func unescapeContent(escaped []byte) []byte {
+	unescapedBytes := make([]byte, 0, len(escaped))
+	index := 0
+
+	// only applies to content - do not apply to raw mysql query
+	// tested with php -i, mysql client, and mysqldump and mydumper.
+	// 1. \" in dump becomes " when inserting a mysql row.
+	// 2. \\ in dump becomes \ when inserting a mysql row.
+	// 3. \' in dump becomes ' when inserting a mysql row.
+	// 4. mysql translates newline into \n when creating a mysqldump. Same applies to carriage return.
+	// 5. PHP serialize does not convert the bytes \r or \n into something else - they're as-is.
+	// 6. If using single quotes in php, \r and \n does not get converted into bytes - they become literal backslash and letter.
+	// Generally, to unescape, we need to do the following:
+	// 1. Convert \\ to \
+	// 2. Convert \' to '
+	// 3. Convert \" to "
+
+	backslash := byte('\\')
+
+	for index < len(escaped) {
+
+		if escaped[index] == backslash {
+			unescapedBytePair := getUnescapedBytesIfEscaped(escaped[index : index+2])
+			byteLength := len(unescapedBytePair)
+
+			if byteLength == 1 {
+				unescapedBytes = append(unescapedBytes, unescapedBytePair...)
+				index = index + 2
+				continue
+			}
+		}
+
+		unescapedBytes = append(unescapedBytes, escaped[index])
+		index++
+	}
+
+	return unescapedBytes
 }
 
 func replaceAndFix(line *[]byte, replacements []*Replacement) *[]byte {

--- a/search-replace.go
+++ b/search-replace.go
@@ -233,7 +233,7 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 
 			// this algorithm SHOULD work, but in cases where the original byte count does not match
 			// the actual byte count, it'll error out. We'll add this safeguard here.
-			return nil, fmt.Errorf("faulty data, byte count does not match data size")
+			return nil, fmt.Errorf("faulty serialized data: out-of-bound index access detected")
 		}
 		char := linePart[currentContentIndex]
 		secondChar := linePart[currentContentIndex+1]
@@ -261,7 +261,7 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 		}
 
 		if contentByteCount > originalByteSize {
-			return nil, fmt.Errorf("faulty data, byte count does not match data size")
+			return nil, fmt.Errorf("faulty serialized data: calculated byte count does not match given data size")
 		}
 
 		contentByteCount++
@@ -278,7 +278,7 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 	rebuiltSerializedString := "s:" + strconv.Itoa(contentLength) + ":\\\"" + string(content) + "\\\";"
 
 	if nextSliceFound == false {
-		return nil, fmt.Errorf("end of serialized string not found")
+		return nil, fmt.Errorf("faulty serialized data: end of serialized data not found")
 	}
 
 	result := SerializedReplaceResult{

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -131,6 +131,20 @@ func TestReplace(t *testing.T) {
 			in:  []byte(`('s:21:\"http://automattic.com\";'),('s:21:\"https://a8c.com\";')`),
 			out: []byte(`('s:22:\"https://automattic.com\";'),('s:21:\"https://a8c.com\";')`),
 		},
+		//TODO: Test disabled. This is a really hard problem to solve.
+		// Generally recovering from a 'syntax error' of a parser - which is what we have here, due to the wrong byte size for a8c.com,
+		// is probably impossible. It destroys all offsets and suddenly we lose track of where the tokenization is at.
+		// Self-recovery is prone to error, and might grab the token entrance at the wrong place.
+		// Also, the PHP version of search and replace does not support this either.
+		//{
+		//	testName: "only fix updated strings, with bad data in between",
+		//
+		//	from: []byte("http://automattic.com"),
+		//	to:   []byte("https://automattic.com"),
+		//
+		//	in:  []byte(`('s:21:\"http://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:21:\"http://automattic.com\";')`),
+		//	out: []byte(`('s:22:\"https://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:22:\"https://automattic.com\";')`),
+		//},
 		{
 			testName: "emoji from",
 
@@ -157,6 +171,21 @@ func TestReplace(t *testing.T) {
 
 			in:  []byte(`s:11:\"hello-world\";`),
 			out: []byte(`s:13:\"goodbye-world\";`),
+		},
+		{
+			testName: "string encoded by both MySQL and PHP",
+
+			from: []byte(`http:\\/\\/example\\.com`),
+			to:   []byte(`http:\\/\\/example2\\.com`),
+			in:   []byte(`s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";`),
+			out:  []byte(`s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`),
+		},
+		{
+			testName: "lots of encoding",
+			from:     []byte(`\\c\\d\\e`),
+			to:       []byte(`\\x`),
+			in:       []byte(`s:18:\"\\a\\b\\c\\d\\e\\f\\g\\h\";\";`),
+			out:      []byte(`s:14:\"\\a\\b\\x\\f\\g\\h\";\";`),
 		},
 		{
 			testName: "search and replace with different lengths",

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -135,7 +135,6 @@ func TestReplace(t *testing.T) {
 		// Generally recovering from a 'syntax error' of a parser - which is what we have here, due to the wrong byte size for a8c.com,
 		// is probably impossible. It destroys all offsets and suddenly we lose track of where the tokenization is at.
 		// Self-recovery is prone to error, and might grab the token entrance at the wrong place.
-		// Also, the PHP version of search and replace does not support this either.
 		//{
 		//	testName: "only fix updated strings, with bad data in between",
 		//
@@ -201,6 +200,20 @@ func TestReplace(t *testing.T) {
 			to:       []byte(`\\x`),
 			in:       []byte(`s:18:\"\\a\\b\\c\\d\\e\\f\\g\\h\";\";`),
 			out:      []byte(`s:14:\"\\a\\b\\x\\f\\g\\h\";\";`),
+		},
+		{
+			testName: "escaped delimiters",
+			from:     []byte(`hello`),
+			to:       []byte(`helloworld`),
+			in:       []byte(`('s:34:\"\";\";\";\";\";\\\";\\\";\\\"; hello \\\\\";\\\\\";\";')`),
+			out:      []byte(`('s:39:\"\";\";\";\";\";\\\";\\\";\\\"; helloworld \\\\\";\\\\\";\";')`),
+		},
+		{
+			testName: "mydumper escaped delimiters",
+			from:     []byte(`hello`),
+			to:       []byte(`helloworld`),
+			in:       []byte(`("s:34:\"\";\";\";\";\";\\\";\\\";\\\"; hello \\\\\";\\\\\";\";")`),
+			out:      []byte(`("s:39:\"\";\";\";\";\";\\\";\\\";\\\"; helloworld \\\\\";\\\\\";\";")`),
 		},
 		{
 			testName: "search and replace with different lengths",

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -81,7 +81,7 @@ func TestReplace(t *testing.T) {
 			from: []byte("http://🖖.com"),
 			to:   []byte("https://spock.com"),
 
-			in:  []byte(`s:12:\"http://🖖.com\";`),
+			in:  []byte(`s:15:\"http://🖖.com\";`),
 			out: []byte(`s:17:\"https://spock.com\";`),
 		},
 		{
@@ -92,6 +92,24 @@ func TestReplace(t *testing.T) {
 
 			in:  []byte(`s:17:\"https://spock.com\";`),
 			out: []byte(`s:15:\"http://🖖.com\";`),
+		},
+		{
+			testName: "search and replace with different lengths",
+
+			from: []byte("hello"),
+			to:   []byte("goodbye"),
+
+			in:  []byte(`s:11:\"hello-world\";`),
+			out: []byte(`s:13:\"goodbye-world\";`),
+		},
+		{
+			testName: "search and replace with different lengths",
+
+			from: []byte("bbbbbbbbbb"),
+			to:   []byte("ccccccccccccccc"),
+
+			in:  []byte(`s:20:\"aaaaabbbbbbbbbbaaaaa\";`),
+			out: []byte(`s:25:\"aaaaacccccccccccccccaaaaa\";`),
 		},
 	}
 

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -188,12 +188,12 @@ func TestReplace(t *testing.T) {
 			out:  []byte(`s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`),
 		},
 		{
-			testName: "serialized repetition",
+			testName: "non-serial replacement trying to apply itself to serial replacement",
 
 			from: []byte(`example`),
 			to:   []byte(`example2`),
-			in:   []byte(`s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";`),
-			out:  []byte(`s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`),
+			in:   []byte(`('example'),('s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";')`),
+			out:  []byte(`('example2'),('s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";')`),
 		},
 		{
 			testName: "lots of encoding",

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -188,6 +188,14 @@ func TestReplace(t *testing.T) {
 			out:  []byte(`s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`),
 		},
 		{
+			testName: "serialized repetition",
+
+			from: []byte(`example`),
+			to:   []byte(`example2`),
+			in:   []byte(`s:37:\"\\s=\\shttp_get\\(\'http:\\/\\/example\\.com\";`),
+			out:  []byte(`s:38:\"\\s=\\shttp_get\\(\'http:\\/\\/example2\\.com\";`),
+		},
+		{
 			testName: "lots of encoding",
 			from:     []byte(`\\c\\d\\e`),
 			to:       []byte(`\\x`),

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -283,7 +283,7 @@ func TestMultiReplace(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			replaced := replaceAndFix(&test.in, test.replacements)
+			replaced := fixLine(&test.in, test.replacements)
 
 			if !bytes.Equal(*replaced, test.out) {
 				t.Error("Expected:", string(test.out), "Actual:", string(*replaced))

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -12,7 +12,35 @@ func BenchmarkFix(b *testing.B) {
 	}
 }
 
-func BenchmarkSimpleReplace(b *testing.B) {
+func BenchmarkNoReplaceOld(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("bananas")
+	to := []byte("apples")
+	for i := 0; i < b.N; i++ {
+		replaceAndFix(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkNoReplaceNew(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("bananas")
+	to := []byte("apples")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSimpleReplaceOld(b *testing.B) {
 	line := []byte("http://automattic.com")
 	from := []byte("http:")
 	to := []byte("https:")
@@ -26,12 +54,40 @@ func BenchmarkSimpleReplace(b *testing.B) {
 	}
 }
 
-func BenchmarkSerializedReplace(b *testing.B) {
+func BenchmarkSimpleReplaceNew(b *testing.B) {
+	line := []byte("http://automattic.com")
+	from := []byte("http:")
+	to := []byte("https:")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSerializedReplaceOld(b *testing.B) {
 	line := []byte(`s:0:\"http://automattic.com\";`)
 	from := []byte("http://automattic.com")
 	to := []byte("https://automattic.com")
 	for i := 0; i < b.N; i++ {
 		replaceAndFix(&line, []*Replacement{
+			{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+}
+
+func BenchmarkSerializedReplaceNew(b *testing.B) {
+	line := []byte(`s:0:\"http://automattic.com\";`)
+	from := []byte("http://automattic.com")
+	to := []byte("https://automattic.com")
+	for i := 0; i < b.N; i++ {
+		fixLine(&line, []*Replacement{
 			{
 				From: from,
 				To:   to,
@@ -115,7 +171,7 @@ func TestReplace(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			replaced := replaceAndFix(&test.in, []*Replacement{
+			replaced := fixLine(&test.in, []*Replacement{
 				{
 					From: test.from,
 					To:   test.to,

--- a/search-replace_test.go
+++ b/search-replace_test.go
@@ -173,6 +173,13 @@ func TestReplace(t *testing.T) {
 			out: []byte(`s:13:\"goodbye-world\";`),
 		},
 		{
+			testName: "serialized CSS",
+			from:     []byte(`https://uss-enterprise.com`),
+			to:       []byte(`https://ncc-1701-d.space`),
+			in:       []byte(`a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:208:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://uss-enterprise.com/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`),
+			out:      []byte(`a:2:{s:3:\"key\";s:5:\"value\";s:3:\"css\";s:206:\"body { color: #123456;\r\nborder-bottom: none; }\r\ndiv.bg { background: url('https://ncc-1701-d.space/wp-content/uploads/main-bg.gif');\r\n  background-position: left center;\r\n    background-repeat: no-repeat; }\";}`),
+		},
+		{
 			testName: "string encoded by both MySQL and PHP",
 
 			from: []byte(`http:\\/\\/example\\.com`),


### PR DESCRIPTION
Hello, this PR is an alternative to the PR in #39 and should fix #33 .

Regex isn't too great for this purpose, as it has a tendency to over-match. Hence, this PR offers an alternative solution.

This PR uses a mini-tokenizer/parser to detect instances of PHP String, then do search-replace in the constraints of the token, then go back up the stack to recalculate the new byte size.

Special care has been taken care so that we didn't include MySQL's sqldump escaping.

It should technically work with mydumper as well - upon inspecting a mydumper dump, the escaping is very much the same.

There's a few errors with the tests in the PR #39 which I've fixed, as well as added new tests to handle some edge cases with excessive escaping, as well as with very plausible scenario of someone using the string combination of `\";` i.e. in WP posts.

If approved, I'll re-point the branch to trunk and merge it from there.