### PR TITLE
Increase io buffer size to 16MB

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,8 @@ func main() {
 	go func() {
 		defer wg.Done()
 
-		r := bufio.NewReaderSize(os.Stdin, 2*1024*1024)
+		bufferSize := 16 * 1024 * 1024 // 16 MB
+		r := bufio.NewReaderSize(os.Stdin, bufferSize)
 		for {
 			line, err := r.ReadBytes('\n')
 


### PR DESCRIPTION
Some files can have extremely large lines which exceed the 2MB buffer we were using. Set the size to a much larger limit to avoid this.

props @luismulinari 