### PR TITLE
README: Remove Travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Go Search Replace
 
-[![Build Status](https://travis-ci.org/Automattic/go-search-replace.svg?branch=master)](https://travis-ci.org/Automattic/go-search-replace)
-
 Search & replace URLs in WordPress SQL files.
 
 ```


### PR DESCRIPTION
We don't use Travis any more.