### PR TITLE
FIx search-replace issues when null terminators are in serialized strings

### DIFF
--- a/searchreplace/search-replace.go
+++ b/searchreplace/search-replace.go
@@ -189,7 +189,14 @@ func getUnescapedBytesIfEscaped(charPair []byte) []byte {
 		't':  '\t',
 		'b':  '\b',
 		'f':  '\f',
-		'0':  '\x00',
+		// This should actually be '\x00' instead of '0', but golang do strange things
+		// like terminating length calculations early, if we put a NULL terminator in an array
+		// likely because it thought that the NULL terminator is the end of an array in the memory.
+		//
+		// This is a workaround and doesn't match the function's name, but right now the function
+		// is only being used measuring how many bytes there are, if we unescape the escaped byte representation.
+		// Hence, this is a safe workaround for now.
+		'0': '0',
 	}
 
 	actualByte := unescapedMap[charPair[1]]

--- a/searchreplace/search-replace_test.go
+++ b/searchreplace/search-replace_test.go
@@ -163,6 +163,14 @@ func TestReplace(t *testing.T) {
 			out: []byte(`s:15:\"http://🖖.com\";`),
 		},
 		{
+			testName: "NULL character (\\0)",
+			from:     []byte("EnvironmentObject"),
+			to:       []byte("Yeehaw"),
+
+			in:  []byte(`s:30:\"\0EnvironmentObject\0wp_site_url\";`),
+			out: []byte(`s:19:\"\0Yeehaw\0wp_site_url\";`),
+		},
+		{
 			testName: "search and replace with different lengths",
 
 			from: []byte("hello"),


### PR DESCRIPTION
# Description

As per the title.. this fixes SR issues when null terminators are in serialized strings.

# Steps to test

The test case should be enough, so let's use that.

1. Revert the change in `search-replace.go`
2. The new test in `search-replace_test.go` will fail.
3. Re-apply the change.
4. The new test in `search-replace_test.go` will pass.
5. Also verify in a PHP repl that `unserialize("s:19:\"\0Yeehaw\0wp_site_url\";");` doesn't error out.