### PR TITLE
chore: update base image and add features

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {
+      "version": "1.0.15",
+      "resolved": "ghcr.io/devcontainers-extra/features/ripgrep@sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2",
+      "integrity": "sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.0.12",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:183d18b42de353e3689615fd21eb67427bc1f763c5b830c2798dcbb993da2049",

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -4,6 +4,11 @@
       "version": "1.0.12",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:183d18b42de353e3689615fd21eb67427bc1f763c5b830c2798dcbb993da2049",
       "integrity": "sha256:183d18b42de353e3689615fd21eb67427bc1f763c5b830c2798dcbb993da2049"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,11 @@
 				"GitHub.copilot",
 				"GitHub.copilot-chat",
 				"github.vscode-github-actions",
-				"ms-vsliveshare.vsliveshare"
+				"ms-vsliveshare.vsliveshare",
+				"phoihos.git-commit-message-editor",
+				"mhutchie.git-graph",
+				"huizhou.githd",
+				"Everspace.rightclick-git"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,16 @@
 	"image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {
-			"installDirectlyFromGitHubRelease": true,
 			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/node:2": {
-			"nodeGypDependencies": true,
 			"version": "lts",
 			"npmVersion": "latest",
 			"pnpmVersion": "none",
 			"nvmVersion": "latest"
+		},
+		"ghcr.io/devcontainers-extra/features/ripgrep:1": {
+			"version": "latest"
 		}
 	},
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,18 @@
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:2": {
+			"nodeGypDependencies": true,
+			"version": "lts",
+			"npmVersion": "latest",
+			"pnpmVersion": "none",
+			"nvmVersion": "latest"
+		}
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,13 @@
 				"mhutchie.git-graph",
 				"huizhou.githd",
 				"Everspace.rightclick-git"
-			]
+			],
+			"settings": {
+				"chat.tools.terminal.terminalProfile.linux": {
+					"path": "/bin/sh",
+					"args": ["-c", "/usr/bin/bash --init-file \"$(code --locate-shell-integration-path bash)\""]
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request updates the development container configuration to provide a more up-to-date and fully featured environment. The main changes include upgrading the Go image version, enhancing the GitHub CLI setup, and adding Node.js support with essential dependencies.

**Dev container base image update:**

* Upgraded the Go dev container image from version `1-1.23-bookworm` to `1.25-bookworm` because the old image has issues with outdated repository signatures and, as a result, failing `apt-get update` commands.

**Feature enhancements:**

* Enhanced the `github-cli` feature by configuring it to install directly from GitHub releases and always use the latest version.
* Added the `node` feature (version 2) to the dev container, installing the LTS version of Node.js, the latest `npm`, no `pnpm`, the latest `nvm`, and all required node-gyp dependencies for native module support. This is to allow for running MCP servers with npx (e.g., Linear) [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R15) [[2]](diffhunk://#diff-cd9c61f8ff24fb9bcc3663e346e2cfa419cfb84e02aae18d3dc66dd192681696R7-R11)