### PR TITLE
refactor: harden serialized bounds checks

### DIFF
--- a/searchreplace/search-replace.go
+++ b/searchreplace/search-replace.go
@@ -83,7 +83,10 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 
 	originalBytes := linePart[match[2]:match[3]]
 
-	originalByteSize, _ := strconv.Atoi(string(originalBytes))
+	originalByteSize, err := strconv.Atoi(string(originalBytes))
+	if err != nil {
+		return nil, fmt.Errorf("faulty serialized data: invalid declared byte count: %w", err)
+	}
 
 	contentStartIndex := match[1]
 

--- a/searchreplace/search-replace.go
+++ b/searchreplace/search-replace.go
@@ -85,11 +85,7 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 
 	originalByteSize, _ := strconv.Atoi(string(originalBytes))
 
-	// the following assumes escaped double quotes
-	// i.e. s:5:\"x -> we'll need to shift our index from '5' to 'x' - hence shifting by 3
-	// MySQL can optionally not escape the double quote,
-	// but generally sqldumps always include the quotes.
-	contentStartIndex := match[3] + 3
+	contentStartIndex := match[1]
 
 	currentContentIndex := contentStartIndex
 
@@ -104,21 +100,15 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 	quote := byte('"')
 	nextSliceFound := false
 
-	maxIndex := len(linePart) - 1
-
 	// let's find where the content actually ends.
 	// it should end when the unescaped value is `";`
 	for currentContentIndex < len(linePart) {
-		if currentContentIndex+2 > maxIndex {
-
-			// this algorithm SHOULD work, but in cases where the original byte count does not match
-			// the actual byte count, it'll error out. We'll add this safeguard here.
-			return nil, fmt.Errorf("faulty serialized data: out-of-bound index access detected")
-		}
 		char := linePart[currentContentIndex]
-		secondChar := linePart[currentContentIndex+1]
-		thirdChar := linePart[currentContentIndex+2]
 		if char == backslash && contentByteCount < originalByteSize {
+			if currentContentIndex+1 >= len(linePart) {
+				return nil, fmt.Errorf("faulty serialized data: incomplete escaped byte pair")
+			}
+
 			unescapedBytePair := getUnescapedBytesIfEscaped(linePart[currentContentIndex : currentContentIndex+2])
 			// if we get the byte pair without the backslash, it corresponds to a byte
 			contentByteCount += len(unescapedBytePair)
@@ -128,16 +118,25 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 			continue
 		}
 
-		if char == backslash && secondChar == quote && thirdChar == semicolon && contentByteCount >= originalByteSize {
+		if char == backslash && contentByteCount >= originalByteSize {
+			if currentContentIndex+2 >= len(linePart) {
+				return nil, fmt.Errorf("faulty serialized data: incomplete serialized data terminator")
+			}
 
-			// we're at backslash
+			secondChar := linePart[currentContentIndex+1]
+			thirdChar := linePart[currentContentIndex+2]
 
-			// index of the beginning of the next slice
-			nextSliceIndex = currentContentIndex + 3
-			// we're at backslash, so we need to minus 1 to get the index where the content finishes
-			contentEndIndex = currentContentIndex - 1
-			nextSliceFound = true
-			break
+			if secondChar == quote && thirdChar == semicolon {
+
+				// we're at backslash
+
+				// index of the beginning of the next slice
+				nextSliceIndex = currentContentIndex + 3
+				// we're at backslash, so we need to minus 1 to get the index where the content finishes
+				contentEndIndex = currentContentIndex - 1
+				nextSliceFound = true
+				break
+			}
 		}
 
 		if contentByteCount > originalByteSize {
@@ -148,6 +147,10 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 		currentContentIndex++
 	}
 
+	if nextSliceFound == false {
+		return nil, fmt.Errorf("faulty serialized data: end of serialized data not found")
+	}
+
 	content := append([]byte{}, linePart[contentStartIndex:contentEndIndex+1]...)
 
 	content = replaceByPart(content, replacements)
@@ -156,10 +159,6 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 
 	// and we rebuild the string
 	rebuiltSerializedString := "s:" + strconv.Itoa(contentLength) + ":\\\"" + string(content) + "\\\";"
-
-	if nextSliceFound == false {
-		return nil, fmt.Errorf("faulty serialized data: end of serialized data not found")
-	}
 
 	result := SerializedReplaceResult{
 		Pre:               pre,
@@ -173,6 +172,10 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 func getUnescapedBytesIfEscaped(charPair []byte) []byte {
 
 	backslash := byte('\\')
+
+	if len(charPair) < 2 {
+		return charPair
+	}
 
 	// if the first byte is not a backslash, we don't need to do anything - we'll return the bytes
 	// as per the function name, we'll return both bytes, or return one byte if one byte is actually an escape character
@@ -222,7 +225,7 @@ func unescapeContent(escaped []byte) []byte {
 
 	for index < len(escaped) {
 
-		if escaped[index] == backslash {
+		if escaped[index] == backslash && index+1 < len(escaped) {
 			unescapedBytePair := getUnescapedBytesIfEscaped(escaped[index : index+2])
 			byteLength := len(unescapedBytePair)
 

--- a/searchreplace/search-replace_test.go
+++ b/searchreplace/search-replace_test.go
@@ -381,6 +381,10 @@ func TestFixLineMalformedSerializedData(t *testing.T) {
 			testName: "overflowing declared byte count",
 			in:       []byte(`s:999999999999999999999999:\"x\";`),
 		},
+		{
+			testName: "negative-ish overflowing declared byte count via even-larger digits",
+			in:       []byte(`s:99999999999999999999999999999999999999999999999999:\"x\";`),
+		},
 	}
 
 	for _, test := range tests {

--- a/searchreplace/search-replace_test.go
+++ b/searchreplace/search-replace_test.go
@@ -347,3 +347,110 @@ func TestFix(t *testing.T) {
 		})
 	}
 }
+
+func TestFixLineMalformedSerializedData(t *testing.T) {
+	var tests = []struct {
+		testName string
+		in       []byte
+	}{
+		{
+			testName: "claimed byte count larger than content",
+			in:       []byte(`s:100:\"short\";`),
+		},
+		{
+			testName: "prefix only incomplete marker",
+			in:       []byte(`s:10:\"`),
+		},
+		{
+			testName: "unterminated serialized content before EOF",
+			in:       []byte(`s:5:\"short`),
+		},
+		{
+			testName: "incomplete trailing escape near EOF",
+			in:       []byte(`s:10:\"short\`),
+		},
+		{
+			testName: "EOF during terminator probe after declared byte count reached",
+			in:       []byte(`s:1:\"a\`),
+		},
+		{
+			testName: "EOF during escaped byte pair before declared byte count reached",
+			in:       []byte(`s:2:\"a\`),
+		},
+		{
+			testName: "overflowing declared byte count",
+			in:       []byte(`s:999999999999999999999999:\"x\";`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			line := append([]byte{}, test.in...)
+			expected := append([]byte{}, test.in...)
+
+			replaced := FixLine(&line, []*Replacement{
+				{
+					From: []byte("short"),
+					To:   []byte("longer"),
+				},
+			})
+
+			if !bytes.Equal(*replaced, expected) {
+				t.Error("Expected:", string(expected), "Actual:", string(*replaced))
+			}
+		})
+	}
+}
+
+func TestGetUnescapedBytesIfEscapedMalformedInput(t *testing.T) {
+	var tests = []struct {
+		testName string
+		in       []byte
+		out      []byte
+	}{
+		{
+			testName: "nil input",
+			in:       nil,
+			out:      nil,
+		},
+		{
+			testName: "single backslash",
+			in:       []byte(`\`),
+			out:      []byte(`\`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			unescaped := getUnescapedBytesIfEscaped(test.in)
+
+			if !bytes.Equal(unescaped, test.out) {
+				t.Error("Expected:", string(test.out), "Actual:", string(unescaped))
+			}
+		})
+	}
+}
+
+func TestUnescapeContentMalformedTrailingBackslash(t *testing.T) {
+	var tests = []struct {
+		testName string
+		in       []byte
+		out      []byte
+	}{
+		{
+			testName: "trailing single backslash",
+			in:       []byte(`short\`),
+			out:      []byte(`short\`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			unescaped := unescapeContent(test.in)
+
+			if !bytes.Equal(unescaped, test.out) {
+				t.Error("Expected:", string(test.out), "Actual:", string(unescaped))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Hardens serialized string parsing to prevent access to malformed input out of bounds while preserving malformed serialized segments unchanged through the existing fallback path.

## Changes

- Uses safer serialized content start handling and adds explicit bounds checks before escaped-byte and terminator lookahead reads.
- Returns malformed-data errors when parsing cannot safely continue, including incomplete escape pairs, incomplete terminator probes, and missing terminators.
- Handles invalid or overflowing declared byte counts explicitly by returning an error from declared-size parsing rather than relying on implicit loop termination.
- Expands regression coverage for malformed/truncated serialized inputs, including:
  - prefix-only and unterminated content
  - trailing incomplete escapes and EOF probe edges
  - oversized and overflowed declared byte counts
  - malformed helper-input edge cases for unescaping behavior

## Testing and Validation

- Local validation:
  - go test ./...
- CI validation:
  - Build and Test workflow check build: SUCCESS

## Risks and Follow-up

- Residual risk is low and centered on uncommon malformed serialized payload shapes not represented in existing fixtures.
- Future hardening could add fuzz coverage around serialized parser boundary conditions.

Related issue: https://linear.app/a8c/issue/PLTFRM-2237/out-of-bounds-index-access
