### PR TITLE
feat(cli): harden CLI input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ be used in domain names. Since the most common usage for search-replace is
 changing domain names or switching http: to https:, this is an easy way to avoid
 otherwise complex issues.
 
+CLI replacement values may be bare tokens such as `sections` or `https`, scheme
+tokens `http:` and `https:`, bare hosts/domains with optional numeric ports and
+safe path segments such as `example.com:8080/wp-content`, or full `http://` and
+`https://` URLs with a host. Filesystem-style paths, traversal segments,
+unsupported schemes, userinfo, query strings, and fragments are rejected before
+input processing begins.
+
+At most one replacement pair may expand its input per invocation.
+
 ## Installation
 
 ### From Official Releases

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ safe path segments such as `example.com:8080/wp-content`, or full `http://` and
 unsupported schemes, userinfo, query strings, and fragments are rejected before
 input processing begins.
 
-At most one replacement pair may expand its input per invocation.
+Replacement pairs are bounded to prevent output blow-up. Each `<to>` value may
+be at most 16× the byte length of its paired `<from>`, and at most one pair per
+invocation may expand its input (i.e. produce a `<to>` longer than its
+`<from>`). The same 16× factor also bounds the cumulative expansion across the
+ordered replacement chain, so later pairs cannot combine with earlier ones —
+including across replacement boundaries — to exceed the per-input limit.
 
 ## Installation
 

--- a/main.go
+++ b/main.go
@@ -5,8 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -14,18 +18,60 @@ import (
 )
 
 const (
-	badInputRe   = `\w:\d+:`
-	inputRe      = `^[A-Za-z0-9_\-\.:/]+$`
-	minInLength  = 4
-	minOutLength = 2
+	badInputRe          = `\w:\d+:`
+	inputRe             = `^[A-Za-z0-9_\-\.:/]+$`
+	safePartRe          = `^[A-Za-z0-9_.-]+$`
+	minInLength         = 4
+	minOutLength        = 2
+	maxArgumentLength   = 2048
+	maxReplacementPairs = 64
+	maxExpansionFactor  = 16
+	exitUsage           = 1
+	exitInvalidFrom     = 2
+	exitInvalidTo       = 3
 
 	version = "0.0.11"
 )
 
 var (
-	input = regexp.MustCompile(inputRe)
-	bad   = regexp.MustCompile(badInputRe)
+	input    = regexp.MustCompile(inputRe)
+	bad      = regexp.MustCompile(badInputRe)
+	safePart = regexp.MustCompile(safePartRe)
 )
+
+type replacementArgError struct {
+	message  string
+	exitCode int
+}
+
+type replacementPair struct {
+	from   string
+	to     string
+	number int
+}
+
+func (err replacementArgError) Error() string {
+	return err.message
+}
+
+func (err replacementArgError) ExitCode() int {
+	return err.exitCode
+}
+
+func newReplacementArgError(exitCode int, format string, args ...interface{}) error {
+	return replacementArgError{
+		message:  fmt.Sprintf(format, args...),
+		exitCode: exitCode,
+	}
+}
+
+func replacementArgExitCode(err error) int {
+	if errWithExitCode, ok := err.(interface{ ExitCode() int }); ok {
+		return errWithExitCode.ExitCode()
+	}
+
+	return exitInvalidFrom
+}
 
 func main() {
 	versionFlag := flag.Bool("version", false, "Show version information")
@@ -37,36 +83,24 @@ func main() {
 		return
 	}
 
-	if len(os.Args) < 3 {
+	args := flag.Args()
+
+	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: search-replace <from> <to>")
-		os.Exit(1)
+		os.Exit(exitUsage)
 		return
 	}
 
-	var replacements []*searchreplace.Replacement
-	args := os.Args[1:]
-
-	if len(args)%2 > 0 {
-		fmt.Fprintln(os.Stderr, "All replacements must have a <from> and <to> value")
-		os.Exit(1)
+	if err := validateReplacementArgs(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(replacementArgExitCode(err))
 		return
 	}
 
-	var from, to string
+	replacements := make([]*searchreplace.Replacement, 0, len(args)/2)
 	for i := 0; i < len(args)/2; i++ {
-		from = args[i*2]
-		if !validInput(from, minInLength) {
-			fmt.Fprintln(os.Stderr, "Invalid <from> URL, minimum length is 4")
-			os.Exit(2)
-			return
-		}
-
-		to = args[(i*2)+1]
-		if !validInput(to, minOutLength) {
-			fmt.Fprintln(os.Stderr, "Invalid <to>, minimum length is 2")
-			os.Exit(3)
-			return
-		}
+		from := args[i*2]
+		to := args[(i*2)+1]
 
 		replacements = append(replacements, &searchreplace.Replacement{
 			From: []byte(from),
@@ -142,19 +176,363 @@ func process(input io.Reader, output io.Writer, errorOutput io.Writer, replaceme
 }
 
 func validInput(in string, length int) bool {
+	return validateInput(in, length) == nil
+}
+
+func validateReplacementArgs(args []string) error {
+	if len(args)%2 > 0 {
+		return newReplacementArgError(exitUsage, "All replacements must have a <from> and <to> value")
+	}
+
+	if len(args)/2 > maxReplacementPairs {
+		return newReplacementArgError(exitInvalidFrom, "Too many replacement pairs: maximum is %d", maxReplacementPairs)
+	}
+
+	seenFrom := map[string]bool{}
+	expandingPairSeen := false
+	pairs := make([]replacementPair, 0, len(args)/2)
+
+	for i := 0; i < len(args)/2; i++ {
+		pairNumber := i + 1
+		from := args[i*2]
+		to := args[(i*2)+1]
+
+		if err := validateInput(from, minInLength); err != nil {
+			return newReplacementArgError(exitInvalidFrom, "Invalid <from> at pair %d: %v", pairNumber, err)
+		}
+
+		if seenFrom[from] {
+			return newReplacementArgError(exitInvalidFrom, "Invalid <from> at pair %d: duplicate <from> value", pairNumber)
+		}
+		seenFrom[from] = true
+
+		if err := validateInput(to, minOutLength); err != nil {
+			return newReplacementArgError(exitInvalidTo, "Invalid <to> at pair %d: %v", pairNumber, err)
+		}
+
+		if from == to {
+			return newReplacementArgError(exitInvalidFrom, "Invalid replacement at pair %d: <from> and <to> must be different", pairNumber)
+		}
+
+		if len(to) > len(from)*maxExpansionFactor {
+			return newReplacementArgError(exitInvalidTo, "Invalid <to> at pair %d: replacement expands <from> by more than %dx", pairNumber, maxExpansionFactor)
+		}
+
+		if len(to) > len(from) {
+			if expandingPairSeen {
+				return newReplacementArgError(exitInvalidTo, "Invalid <to> at pair %d: only one expanding replacement pair is allowed per invocation", pairNumber)
+			}
+			expandingPairSeen = true
+		}
+
+		pairs = append(pairs, replacementPair{
+			from:   from,
+			to:     to,
+			number: pairNumber,
+		})
+	}
+
+	if err := validateOrderedExpansionChains(pairs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateOrderedExpansionChains(pairs []replacementPair) error {
+	for earlierIndex := 0; earlierIndex < len(pairs); earlierIndex++ {
+		earlier := pairs[earlierIndex]
+		current := earlier.to
+		limit := len(earlier.from) * maxExpansionFactor
+
+		for laterIndex := earlierIndex + 1; laterIndex < len(pairs); laterIndex++ {
+			later := pairs[laterIndex]
+
+			if len(later.to) > len(later.from) {
+				if err := validateBoundaryExpansionChain(earlier, current, later); err != nil {
+					return err
+				}
+			}
+
+			updated, ok := replaceAllWithLimit(current, later.from, later.to, limit)
+			if !ok {
+				return newReplacementArgError(
+					exitInvalidTo,
+					"Invalid ordered expansion chain between pairs %d and %d: cumulative replacement expansion exceeds %dx",
+					earlier.number,
+					later.number,
+					maxExpansionFactor,
+				)
+			}
+
+			current = updated
+		}
+	}
+
+	return nil
+}
+
+func replaceAllWithLimit(in string, from string, to string, limit int) (string, bool) {
+	count := strings.Count(in, from)
+	if count == 0 {
+		return in, true
+	}
+
+	updatedLength := len(in) + count*(len(to)-len(from))
+	if updatedLength > limit {
+		return "", false
+	}
+
+	return strings.ReplaceAll(in, from, to), true
+}
+
+func validateBoundaryExpansionChain(earlier replacementPair, current string, later replacementPair) error {
+	overlapCount := aggregateBoundaryOverlapCount(current, later.from)
+	if overlapCount == 0 {
+		return nil
+	}
+
+	matchCount := (overlapCount + len(later.from) - 1) / len(later.from)
+	originalLength := len(earlier.from) + matchCount*len(later.from) - overlapCount
+	updatedLength := len(current) - overlapCount + matchCount*len(later.to)
+
+	if updatedLength > originalLength*maxExpansionFactor {
+		return newBoundaryExpansionChainError(earlier, later)
+	}
+
+	return nil
+}
+
+func aggregateBoundaryOverlapCount(current string, laterFrom string) int {
+	var bytesInLaterFrom [256]bool
+	for index := 0; index < len(laterFrom); index++ {
+		bytesInLaterFrom[laterFrom[index]] = true
+	}
+
+	count := 0
+	for index := 0; index < len(current); index++ {
+		if bytesInLaterFrom[current[index]] {
+			count++
+		}
+	}
+
+	return count
+}
+
+func newBoundaryExpansionChainError(earlier replacementPair, later replacementPair) error {
+	return newReplacementArgError(
+		exitInvalidTo,
+		"Invalid ordered expansion chain between pairs %d and %d: later expanding <from> can be assembled across a replacement boundary",
+		earlier.number,
+		later.number,
+	)
+}
+
+func validateInput(in string, length int) error {
 	if len(in) < length {
-		return false
+		return fmt.Errorf("minimum length is %d", length)
+	}
+
+	if len(in) > maxArgumentLength {
+		return fmt.Errorf("maximum length is %d bytes", maxArgumentLength)
 	}
 
 	if !input.MatchString(in) {
-		return false
+		return fmt.Errorf("contains unsupported characters")
 	}
 
 	if bad.MatchString(in) {
-		return false
+		return fmt.Errorf("looks like serialized data")
 	}
 
-	return true
+	if strings.Contains(in, "://") {
+		return validateFullURL(in)
+	}
+
+	return validateBareInput(in)
+}
+
+func validateFullURL(in string) error {
+	parsed, err := url.Parse(in)
+	if err != nil {
+		return fmt.Errorf("malformed URL")
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme")
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("URL requires a host")
+	}
+
+	if parsed.User != nil {
+		return fmt.Errorf("URL must not include userinfo")
+	}
+
+	if parsed.RawQuery != "" || parsed.ForceQuery {
+		return fmt.Errorf("URL must not include a query")
+	}
+
+	if parsed.Fragment != "" {
+		return fmt.Errorf("URL must not include a fragment")
+	}
+
+	if err := validateHostPort(parsed.Host); err != nil {
+		return err
+	}
+
+	if err := validatePath(parsed.Path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateBareInput(in string) error {
+	if in == "http:" || in == "https:" {
+		return nil
+	}
+
+	if strings.HasPrefix(in, "/") || strings.HasPrefix(in, "./") || strings.HasPrefix(in, "../") {
+		return fmt.Errorf("must not look like a filesystem path")
+	}
+
+	if strings.Contains(in, "/") {
+		host, path, _ := strings.Cut(in, "/")
+		if err := validateHostPort(host); err != nil {
+			return err
+		}
+
+		return validatePath("/" + path)
+	}
+
+	if strings.Contains(in, ":") {
+		return validateHostPort(in)
+	}
+
+	if !safePart.MatchString(in) {
+		return fmt.Errorf("contains unsupported characters")
+	}
+
+	return nil
+}
+
+func validateHostPort(in string) error {
+	host := in
+	if strings.Contains(in, ":") {
+		if strings.Count(in, ":") > 1 {
+			return fmt.Errorf("malformed port")
+		}
+
+		portIndex := strings.LastIndex(in, ":")
+		host = in[:portIndex]
+		port := in[portIndex+1:]
+		if err := validatePort(port); err != nil {
+			return err
+		}
+	}
+
+	return validateHost(host)
+}
+
+func validateHost(in string) error {
+	if in == "" {
+		return fmt.Errorf("host is required")
+	}
+
+	if len(in) > 253 {
+		return fmt.Errorf("host exceeds maximum length")
+	}
+
+	if strings.EqualFold(in, "localhost") {
+		return nil
+	}
+
+	if ip := net.ParseIP(in); ip != nil && ip.To4() != nil {
+		return nil
+	}
+
+	labels := strings.Split(in, ".")
+	if len(labels) < 2 {
+		return fmt.Errorf("host must be a domain, localhost, or IPv4 address")
+	}
+
+	for _, label := range labels {
+		if label == "" {
+			return fmt.Errorf("host contains an empty label")
+		}
+
+		if len(label) > 63 {
+			return fmt.Errorf("host label exceeds maximum length")
+		}
+
+		if !isAlphaNumeric(label[0]) || !isAlphaNumeric(label[len(label)-1]) {
+			return fmt.Errorf("host labels must start and end with an alphanumeric character")
+		}
+
+		for i := 0; i < len(label); i++ {
+			if !isAlphaNumeric(label[i]) && label[i] != '-' {
+				return fmt.Errorf("host labels may only contain alphanumeric characters or hyphens")
+			}
+		}
+	}
+
+	return nil
+}
+
+func isAlphaNumeric(char byte) bool {
+	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
+}
+
+func validatePort(in string) error {
+	if in == "" {
+		return fmt.Errorf("port is required")
+	}
+
+	for _, char := range in {
+		if char < '0' || char > '9' {
+			return fmt.Errorf("port must be numeric")
+		}
+	}
+
+	port, err := strconv.Atoi(in)
+	if err != nil || port > 65535 {
+		return fmt.Errorf("port must be between 0 and 65535")
+	}
+
+	return nil
+}
+
+func validatePath(in string) error {
+	if in == "" {
+		return nil
+	}
+
+	if !strings.HasPrefix(in, "/") {
+		return fmt.Errorf("path must start with a slash")
+	}
+
+	if strings.Contains(in, "//") {
+		return fmt.Errorf("path must not contain empty segments")
+	}
+
+	trimmedPath := strings.Trim(in, "/")
+	if trimmedPath == "" {
+		return nil
+	}
+
+	for _, segment := range strings.Split(trimmedPath, "/") {
+		if segment == "." || segment == ".." {
+			return fmt.Errorf("path must not contain traversal segments")
+		}
+
+		if !safePart.MatchString(segment) {
+			return fmt.Errorf("path contains unsupported characters")
+		}
+	}
+
+	return nil
 }
 
 func unsafeGetString(bs []byte) string {

--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func validateReplacementArgs(args []string) error {
 	}
 
 	if len(args)/2 > maxReplacementPairs {
-		return newReplacementArgError(exitInvalidFrom, "Too many replacement pairs: maximum is %d", maxReplacementPairs)
+		return newReplacementArgError(exitUsage, "Too many replacement pairs: maximum is %d", maxReplacementPairs)
 	}
 
 	seenFrom := map[string]bool{}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 	args := flag.Args()
 
 	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: search-replace <from> <to>")
+		fmt.Fprintln(os.Stderr, "Usage: search-replace <from> <to> [<from> <to> ...]")
 		os.Exit(exitUsage)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -286,15 +286,20 @@ func replaceAllWithLimit(in string, from string, to string, limit int) (string, 
 	return strings.ReplaceAll(in, from, to), true
 }
 
+// validateBoundaryExpansionChain rejects a later expanding pair whose <from>
+// can be assembled across the seam between two adjacent copies of current
+// (the post-earlier replacement stream) when the resulting amortized output
+// per input copy of earlier.from would exceed maxExpansionFactor.
 func validateBoundaryExpansionChain(earlier replacementPair, current string, later replacementPair) error {
-	overlapCount := aggregateBoundaryOverlapCount(current, later.from)
-	if overlapCount == 0 {
+	if !boundarySeamAssemblesMatch(current, later.from) {
 		return nil
 	}
 
-	matchCount := (overlapCount + len(later.from) - 1) / len(later.from)
-	originalLength := len(earlier.from) + matchCount*len(later.from) - overlapCount
-	updatedLength := len(current) - overlapCount + matchCount*len(later.to)
+	// Amortized worst case: every seam between adjacent copies of current
+	// hosts one later.from match, replaced by later.to. Output per input
+	// copy of earlier.from is len(current) + (len(later.to) - len(later.from)).
+	originalLength := len(earlier.from)
+	updatedLength := len(current) + len(later.to) - len(later.from)
 
 	if updatedLength > originalLength*maxExpansionFactor {
 		return newBoundaryExpansionChainError(earlier, later)
@@ -303,20 +308,41 @@ func validateBoundaryExpansionChain(earlier replacementPair, current string, lat
 	return nil
 }
 
-func aggregateBoundaryOverlapCount(current string, laterFrom string) int {
-	var bytesInLaterFrom [256]bool
-	for index := 0; index < len(laterFrom); index++ {
-		bytesInLaterFrom[laterFrom[index]] = true
+// boundarySeamAssemblesMatch reports whether laterFrom can occur across the
+// boundary between two adjacent copies of current, i.e., whether there is an
+// i in [1, L-1] with current ending in laterFrom[:i] and current beginning
+// with laterFrom[i:]. Equivalent to suffixOverlap + prefixOverlap >= L,
+// where suffixOverlap is the largest k such that current ends with
+// laterFrom[:k] and prefixOverlap is the largest k such that current begins
+// with laterFrom[L-k:].
+func boundarySeamAssemblesMatch(current, laterFrom string) bool {
+	L := len(laterFrom)
+	if L < 2 || len(current) == 0 {
+		return false
 	}
 
-	count := 0
-	for index := 0; index < len(current); index++ {
-		if bytesInLaterFrom[current[index]] {
-			count++
+	maxK := L - 1
+	if maxK > len(current) {
+		maxK = len(current)
+	}
+
+	suffixOverlap := 0
+	for k := maxK; k > 0; k-- {
+		if strings.HasSuffix(current, laterFrom[:k]) {
+			suffixOverlap = k
+			break
 		}
 	}
 
-	return count
+	prefixOverlap := 0
+	for k := maxK; k > 0; k-- {
+		if strings.HasPrefix(current, laterFrom[L-k:]) {
+			prefixOverlap = k
+			break
+		}
+	}
+
+	return suffixOverlap+prefixOverlap >= L
 }
 
 func newBoundaryExpansionChainError(earlier replacementPair, later replacementPair) error {

--- a/main.go
+++ b/main.go
@@ -309,40 +309,27 @@ func validateBoundaryExpansionChain(earlier replacementPair, current string, lat
 }
 
 // boundarySeamAssemblesMatch reports whether laterFrom can occur across the
-// boundary between two adjacent copies of current, i.e., whether there is an
-// i in [1, L-1] with current ending in laterFrom[:i] and current beginning
-// with laterFrom[i:]. Equivalent to suffixOverlap + prefixOverlap >= L,
-// where suffixOverlap is the largest k such that current ends with
-// laterFrom[:k] and prefixOverlap is the largest k such that current begins
-// with laterFrom[L-k:].
+// boundary between two adjacent copies of current, i.e., whether there exists
+// a single split i in [1, L-1] such that current ends with laterFrom[:i] and
+// current also begins with laterFrom[i:]. Each candidate split is checked
+// directly because independently-maximized prefix and suffix overlaps may
+// come from different splits and do not imply a simultaneous match.
 func boundarySeamAssemblesMatch(current, laterFrom string) bool {
 	L := len(laterFrom)
 	if L < 2 || len(current) == 0 {
 		return false
 	}
 
-	maxK := L - 1
-	if maxK > len(current) {
-		maxK = len(current)
-	}
-
-	suffixOverlap := 0
-	for k := maxK; k > 0; k-- {
-		if strings.HasSuffix(current, laterFrom[:k]) {
-			suffixOverlap = k
-			break
+	for i := 1; i < L; i++ {
+		if i > len(current) || L-i > len(current) {
+			continue
+		}
+		if strings.HasSuffix(current, laterFrom[:i]) && strings.HasPrefix(current, laterFrom[i:]) {
+			return true
 		}
 	}
 
-	prefixOverlap := 0
-	for k := maxK; k > 0; k-- {
-		if strings.HasPrefix(current, laterFrom[L-k:]) {
-			prefixOverlap = k
-			break
-		}
-	}
-
-	return suffixOverlap+prefixOverlap >= L
+	return false
 }
 
 func newBoundaryExpansionChainError(earlier replacementPair, later replacementPair) error {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,6 +19,8 @@ var (
 )
 
 func doMainTest(t *testing.T, input string, expected string, mainArgs []string) {
+	t.Helper()
+
 	execArgs := append([]string{"run", basePath}, mainArgs...)
 	cmd := exec.Command("go", execArgs...)
 
@@ -154,6 +157,65 @@ func TestRunReturnsZeroAtEOF(t *testing.T) {
 	}
 }
 
+func doMainFailureTest(t *testing.T, input string, mainArgs []string) (string, string) {
+	t.Helper()
+
+	execArgs := append([]string{"run", basePath}, mainArgs...)
+	cmd := exec.Command("go", execArgs...)
+
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err == nil {
+		t.Fatal("Expected command to fail")
+	}
+
+	return out.String(), stderr.String()
+}
+
+func buildMainBinary(t *testing.T) string {
+	t.Helper()
+
+	binaryPath := filepath.Join(t.TempDir(), "go-search-replace")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", binaryPath, basePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build CLI: %v\n%s", err, output)
+	}
+
+	return binaryPath
+}
+
+func doMainFailureExitCodeTest(t *testing.T, binaryPath string, input string, mainArgs []string) (string, string, int) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, mainArgs...)
+
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("Expected command to fail")
+	}
+
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("Expected exit error, got: %v", err)
+	}
+
+	return out.String(), stderr.String(), exitError.ExitCode()
+}
+
 func TestSimpleReplaceWithNewlineAtEOF(t *testing.T) {
 	mainArgs := []string{
 		"http://uss-enterprise.com",
@@ -229,30 +291,190 @@ func TestSerializedReplaceWithCssAndUnrelatedSerializationMarker(t *testing.T) {
 	doMainTest(t, input, expected, mainArgs)
 }
 
-func TestInput(t *testing.T) {
+func TestValidInput(t *testing.T) {
 	var tests = []struct {
 		testName string
 		in       string
 		valid    bool
 	}{
 		{
-			testName: "Simple domain name",
+			testName: "bare domain",
 			in:       "automattic.com",
 			valid:    true,
 		},
 		{
-			testName: "Short string",
-			in:       "s:",
+			testName: "domain with port",
+			in:       "example.com:8080",
+			valid:    true,
+		},
+		{
+			testName: "domain with path",
+			in:       "example.com/wp-content",
+			valid:    true,
+		},
+		{
+			testName: "localhost with path",
+			in:       "localhost/wp-content",
+			valid:    true,
+		},
+		{
+			testName: "IPv4 with path",
+			in:       "127.0.0.1/wp-content",
+			valid:    true,
+		},
+		{
+			testName: "http URL",
+			in:       "http://uss-enterprise.com",
+			valid:    true,
+		},
+		{
+			testName: "https URL",
+			in:       "https://ncc-1701-d.space",
+			valid:    true,
+		},
+		{
+			testName: "URL with path",
+			in:       "http://old.example.com/wp-content",
+			valid:    true,
+		},
+		{
+			testName: "https token",
+			in:       "https",
+			valid:    true,
+		},
+		{
+			testName: "replacement token",
+			in:       "warp",
+			valid:    true,
+		},
+		{
+			testName: "path segment token from",
+			in:       "sections",
+			valid:    true,
+		},
+		{
+			testName: "path segment token to",
+			in:       "areas",
+			valid:    true,
+		},
+		{
+			testName: "http scheme token",
+			in:       "http:",
+			valid:    true,
+		},
+		{
+			testName: "https scheme token",
+			in:       "https:",
+			valid:    true,
+		},
+		{
+			testName: "too long argument",
+			in:       strings.Repeat("a", maxArgumentLength+1),
+			valid:    false,
+		},
+		{
+			testName: "relative traversal path",
+			in:       "../../etc/passwd",
+			valid:    false,
+		},
+		{
+			testName: "absolute filesystem path",
+			in:       "/tmp/file",
+			valid:    false,
+		},
+		{
+			testName: "relative etc path",
+			in:       "etc/passwd",
+			valid:    false,
+		},
+		{
+			testName: "relative home path",
+			in:       "home/user/.ssh/id_rsa",
+			valid:    false,
+		},
+		{
+			testName: "relative wp content path",
+			in:       "wp-content/uploads",
+			valid:    false,
+		},
+		{
+			testName: "dot slash path",
+			in:       "./example.com",
+			valid:    false,
+		},
+		{
+			testName: "domain path traversal",
+			in:       "example.com/../admin",
+			valid:    false,
+		},
+		{
+			testName: "URL path traversal",
+			in:       "http://example.com/../admin",
+			valid:    false,
+		},
+		{
+			testName: "repeated empty path segments",
+			in:       "http://example.com//admin",
+			valid:    false,
+		},
+		{
+			testName: "unsupported file scheme",
+			in:       "file:///etc/passwd",
+			valid:    false,
+		},
+		{
+			testName: "javascript scheme",
+			in:       "javascript:alert",
+			valid:    false,
+		},
+		{
+			testName: "missing URL host",
+			in:       "http://",
+			valid:    false,
+		},
+		{
+			testName: "malformed URL host",
+			in:       "http:///missing-host",
+			valid:    false,
+		},
+		{
+			testName: "hostname label starts with hyphen",
+			in:       "http://-bad.example.com",
+			valid:    false,
+		},
+		{
+			testName: "hostname label ends with hyphen",
+			in:       "http://bad-.example.com",
+			valid:    false,
+		},
+		{
+			testName: "missing scheme",
+			in:       "://example.com",
+			valid:    false,
+		},
+		{
+			testName: "non-numeric port",
+			in:       "example.com:abc",
+			valid:    false,
+		},
+		{
+			testName: "out of range port",
+			in:       "example.com:99999",
+			valid:    false,
+		},
+		{
+			testName: "array serialization marker",
+			in:       "a:4:",
+			valid:    false,
+		},
+		{
+			testName: "string serialization marker",
+			in:       "s:1:",
 			valid:    false,
 		},
 		{
 			testName: "SQL string",
 			in:       "),(",
-			valid:    false,
-		},
-		{
-			testName: "Serialization structure",
-			in:       "a:4:",
 			valid:    false,
 		},
 	}
@@ -264,5 +486,221 @@ func TestInput(t *testing.T) {
 				t.Error("Expected:", test.valid, "Actual:", valid)
 			}
 		})
+	}
+}
+
+func TestValidateReplacementArgs(t *testing.T) {
+	tests := []struct {
+		testName string
+		args     []string
+		wantErr  string
+	}{
+		{
+			testName: "valid multiple pairs",
+			args: []string{
+				"http://uss-enterprise.com",
+				"https://ncc-1701-d.space",
+				"sections",
+				"areas",
+				"https",
+				"warp",
+			},
+		},
+		{
+			testName: "valid replacement containing from",
+			args:     []string{"http", "https"},
+		},
+		{
+			testName: "valid ordered shrinking chain",
+			args:     []string{"aaaa", "bbbb", "bbbb", "ccc"},
+		},
+		{
+			testName: "valid ordered replacement chain with one expansion",
+			args:     []string{"aaaa", "bbbbbbbb", "bbbb", "cccc"},
+		},
+		{
+			testName: "no-op replacement",
+			args:     []string{"automattic.com", "automattic.com"},
+			wantErr:  "must be different",
+		},
+		{
+			testName: "duplicate from",
+			args:     []string{"automattic.com", "example.com", "automattic.com", "example.org"},
+			wantErr:  "duplicate <from>",
+		},
+		{
+			testName: "max length",
+			args:     []string{strings.Repeat("a", maxArgumentLength+1), "example.com"},
+			wantErr:  "maximum length",
+		},
+		{
+			testName: "expansion factor",
+			args:     []string{"abcd", strings.Repeat("a", len("abcd")*maxExpansionFactor+1)},
+			wantErr:  "expands <from>",
+		},
+		{
+			testName: "multiple expanding pairs",
+			args:     []string{"aaaa", "bbbbbbbb", "bbbb", strings.Repeat("c", len("bbbb")*maxExpansionFactor)},
+			wantErr:  "only one expanding replacement pair",
+		},
+		{
+			testName: "multi-prior-output ordered expansion bypass",
+			args: []string{
+				"aaaa",
+				"bbbbb",
+				"cccc",
+				"ddddd",
+				"bbbbbddddd",
+				strings.Repeat("e", len("bbbbbddddd")*maxExpansionFactor),
+			},
+			wantErr: "only one expanding replacement pair",
+		},
+		{
+			testName: "multiple expanding pairs assembled by intervening replacement",
+			args: []string{
+				"aaaa",
+				"bbbbcccc",
+				"bbbb",
+				"dddd",
+				"ddddcccc",
+				strings.Repeat("e", len("ddddcccc")*maxExpansionFactor),
+			},
+			wantErr: "only one expanding replacement pair",
+		},
+		{
+			testName: "multiple expanding pairs assembled across replacement boundary",
+			args: []string{
+				"aaaa",
+				"bbbbbbbb",
+				"bbbbbbbbc",
+				strings.Repeat("e", len("bbbbbbbbc")*maxExpansionFactor),
+			},
+			wantErr: "only one expanding replacement pair",
+		},
+		{
+			testName: "multiple expanding pairs assembled across two-sided replacement boundary",
+			args: []string{
+				"xxxx",
+				"bbbbbbbb",
+				"abbbbbbbbc",
+				strings.Repeat("e", len("abbbbbbbbc")*maxExpansionFactor),
+			},
+			wantErr: "only one expanding replacement pair",
+		},
+		{
+			testName: "multiple expanding pairs assembled across aggregate replacement boundaries",
+			args: []string{
+				"aaaaaaaaaa",
+				"bbbbbbcccccc",
+				"ccccccddddddddbbbbbb",
+				strings.Repeat("e", len("ccccccddddddddbbbbbb")*maxExpansionFactor),
+			},
+			wantErr: "only one expanding replacement pair",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			err := validateReplacementArgs(test.args)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal("Expected no error, got:", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("Expected error containing:", test.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Error("Expected error containing:", test.wantErr, "Actual:", err)
+			}
+		})
+	}
+}
+
+func TestValidationExitCodes(t *testing.T) {
+	binaryPath := buildMainBinary(t)
+
+	tests := []struct {
+		testName string
+		args     []string
+		wantCode int
+		wantErr  string
+	}{
+		{
+			testName: "odd replacement count",
+			args:     []string{"automattic.com", "example.com", "orphaned"},
+			wantCode: exitUsage,
+			wantErr:  "All replacements must have a <from> and <to> value",
+		},
+		{
+			testName: "invalid from",
+			args:     []string{"bad", "example.com"},
+			wantCode: exitInvalidFrom,
+			wantErr:  "Invalid <from>",
+		},
+		{
+			testName: "invalid to",
+			args:     []string{"automattic.com", "x"},
+			wantCode: exitInvalidTo,
+			wantErr:  "Invalid <to>",
+		},
+		{
+			testName: "multiple expanding pairs",
+			args:     []string{"aaaa", "bbbbb", "cccc", "ddddd"},
+			wantCode: exitInvalidTo,
+			wantErr:  "only one expanding replacement pair",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			stdout, stderr, exitCode := doMainFailureExitCodeTest(t, binaryPath, "", test.args)
+
+			if stdout != "" {
+				t.Error("Expected no stdout, got:", stdout)
+			}
+
+			if exitCode != test.wantCode {
+				t.Error("Expected exit code:", test.wantCode, "Actual:", exitCode)
+			}
+
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Error("Expected stderr containing:", test.wantErr, "Actual:", stderr)
+			}
+		})
+	}
+}
+
+func TestTooManyReplacementPairs(t *testing.T) {
+	args := make([]string, 0, (maxReplacementPairs+1)*2)
+	for i := 0; i <= maxReplacementPairs; i++ {
+		args = append(args, "from"+strconv.Itoa(i), "to"+strconv.Itoa(i))
+	}
+
+	err := validateReplacementArgs(args)
+	if err == nil {
+		t.Fatal("Expected too many replacement pairs to fail")
+	}
+
+	if !strings.Contains(err.Error(), "Too many replacement pairs") {
+		t.Error("Expected too many pairs error, got:", err)
+	}
+}
+
+func TestInvalidArgsFailBeforeProcessing(t *testing.T) {
+	stdout, stderr := doMainFailureTest(t, "http://uss-enterprise.com\n", []string{
+		"http://",
+		"https://ncc-1701-d.space",
+	})
+
+	if stdout != "" {
+		t.Error("Expected no stdout, got:", stdout)
+	}
+
+	if !strings.Contains(stderr, "Invalid <from>") {
+		t.Error("Expected invalid <from> error, got:", stderr)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -743,3 +743,64 @@ func TestInvalidArgsFailBeforeProcessing(t *testing.T) {
 		t.Error("Expected invalid <from> error, got:", stderr)
 	}
 }
+
+func TestBoundarySeamAssemblesMatch(t *testing.T) {
+	tests := []struct {
+		testName  string
+		current   string
+		laterFrom string
+		want      bool
+	}{
+		{
+			testName:  "mismatched-split max overlaps do not assemble",
+			current:   "cdefabcd",
+			laterFrom: "abcdef",
+			want:      false,
+		},
+		{
+			testName:  "single split assembles full match",
+			current:   "abab",
+			laterFrom: "abababab",
+			want:      true,
+		},
+		{
+			testName:  "current equals laterFrom",
+			current:   "abababab",
+			laterFrom: "abababab",
+			want:      true,
+		},
+		{
+			testName:  "disjoint alphabets",
+			current:   "bbbbbbbbbb",
+			laterFrom: "ccccccc",
+			want:      false,
+		},
+		{
+			testName:  "shared bytes without affix overlap",
+			current:   "bbbbbbbbbb",
+			laterFrom: "cccbbbbbcccbbbbccc",
+			want:      false,
+		},
+		{
+			testName:  "single byte laterFrom never assembles",
+			current:   "aaaa",
+			laterFrom: "a",
+			want:      false,
+		},
+		{
+			testName:  "empty current never assembles",
+			current:   "",
+			laterFrom: "abc",
+			want:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			got := boundarySeamAssemblesMatch(test.current, test.laterFrom)
+			if got != test.want {
+				t.Errorf("boundarySeamAssemblesMatch(%q, %q) = %v, want %v", test.current, test.laterFrom, got, test.want)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -597,6 +597,34 @@ func TestValidateReplacementArgs(t *testing.T) {
 			},
 			wantErr: "only one expanding replacement pair",
 		},
+		{
+			testName: "boundary helper accepts shared bytes without affix overlap",
+			args: []string{
+				"aaaaaaaaaa",
+				"bbbbbbbbbb",
+				"cccbbbbbcccbbbbccc",
+				strings.Repeat("d", len("cccbbbbbcccbbbbccc")*maxExpansionFactor),
+			},
+		},
+		{
+			testName: "boundary expansion rejected when seam assembly compounds",
+			args: []string{
+				"aaaa",
+				"abab",
+				"abababab",
+				strings.Repeat("c", 128),
+			},
+			wantErr: "can be assembled across a replacement boundary",
+		},
+		{
+			testName: "boundary expansion accepted when seam assembly within budget",
+			args: []string{
+				"aaaaaaaa",
+				"abababab",
+				"abababab",
+				strings.Repeat("c", 128),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -623,6 +623,11 @@ func TestValidateReplacementArgs(t *testing.T) {
 func TestValidationExitCodes(t *testing.T) {
 	binaryPath := buildMainBinary(t)
 
+	tooManyPairsArgs := make([]string, 0, (maxReplacementPairs+1)*2)
+	for i := 0; i <= maxReplacementPairs; i++ {
+		tooManyPairsArgs = append(tooManyPairsArgs, "from"+strconv.Itoa(i), "to"+strconv.Itoa(i))
+	}
+
 	tests := []struct {
 		testName string
 		args     []string
@@ -652,6 +657,12 @@ func TestValidationExitCodes(t *testing.T) {
 			args:     []string{"aaaa", "bbbbb", "cccc", "ddddd"},
 			wantCode: exitInvalidTo,
 			wantErr:  "only one expanding replacement pair",
+		},
+		{
+			testName: "too many replacement pairs",
+			args:     tooManyPairsArgs,
+			wantCode: exitUsage,
+			wantErr:  "Too many replacement pairs",
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR hardens CLI replacement-argument validation to reject malformed or unsafe inputs before any stream processing starts, while preserving valid migration patterns for WordPress SQL search-replace use cases.

It also tightens expansion-safety checks to prevent pathological growth across ordered replacement chains, and follows up on review feedback to improve usage/error semantics and boundary-match correctness.

Issue reference: [PLTFRM-2239](https://linear.app/a8c/issue/PLTFRM-2239/insufficient-input-validation)

## Changes

- Added structured replacement-argument validation with explicit error categories and exit-code mapping for usage errors vs invalid `<from>` vs invalid `<to>`.
- Added strict input-form validation for accepted argument shapes (bare token, scheme token, host with optional port/path, or full http/https URL) and rejected unsupported patterns (e.g. traversal, query/fragment/userinfo, malformed host/port forms, serialization markers).
- Added argument-count and size guardrails, duplicate/no-op replacement rejection, and expansion controls.
- Added/updated ordered-chain expansion checks, including seam-assembly handling and a per-split seam predicate fix from review feedback.
- Updated CLI usage text to reflect repeated pair syntax.
- Updated README language for expansion policy (including 16x cap and ordered-chain behavior).
- Added extensive test coverage for validation behavior, exit-code semantics, expansion-chain safety, seam-assembly edge cases, and read-error handling path compatibility from trunk.

## Testing and Validation

- `go test -count=1 ./...` (pass)
- `go vet ./...` (clean)

## Review Notes

- Copilot review comments were addressed in follow-up commits.
- Boundary-overlap logic was revised twice based on review: first to remove byte-set overcounting, then to enforce a single-split seam-match condition.
- All review threads are currently marked resolved.

## Risks and Follow-up

- Validation is intentionally stricter and may reject inputs that were previously tolerated but were ambiguous or unsafe.
- Exit-code handling is now more semantically aligned; downstream scripts that depended on prior misclassified failures should verify expectations.
