### PR TITLE
fix: return nonzero on stdin read errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,49 +74,71 @@ func main() {
 		})
 	}
 
+	if code := run(os.Stdin, os.Stdout, os.Stderr, replacements); code != 0 {
+		os.Exit(code)
+		return
+	}
+}
+
+func run(input io.Reader, output io.Writer, errorOutput io.Writer, replacements []*searchreplace.Replacement) int {
+	if err := process(input, output, errorOutput, replacements); err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func process(input io.Reader, output io.Writer, errorOutput io.Writer, replacements []*searchreplace.Replacement) error {
 	var wg sync.WaitGroup
 	lines := make(chan chan []byte, 10)
+	readErrors := make(chan error, 1)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
 		bufferSize := 16 * 1024 * 1024 // 16 MB
-		r := bufio.NewReaderSize(os.Stdin, bufferSize)
+		r := bufio.NewReaderSize(input, bufferSize)
 		for {
 			line, err := r.ReadBytes('\n')
 
-			if err != nil {
-				if err == io.EOF {
-					if 0 == len(line) {
-						break
-					}
-				} else {
-					fmt.Fprintln(os.Stderr, err.Error())
-					break
-				}
+			if len(line) > 0 {
+				wg.Add(1)
+				ch := make(chan []byte)
+				lines <- ch
+
+				go func(line *[]byte) {
+					defer wg.Done()
+					line = searchreplace.FixLine(line, replacements)
+					ch <- *line
+				}(&line)
 			}
 
-			wg.Add(1)
-			ch := make(chan []byte)
-			lines <- ch
-
-			go func(line *[]byte) {
-				defer wg.Done()
-				line = searchreplace.FixLine(line, replacements)
-				ch <- *line
-			}(&line)
+			if err != nil {
+				if err != io.EOF {
+					fmt.Fprintln(errorOutput, err.Error())
+					readErrors <- err
+				}
+				break
+			}
 		}
 	}()
 
 	go func() {
 		wg.Wait()
 		close(lines)
+		close(readErrors)
 	}()
 
 	for line := range lines {
-		fmt.Print(unsafeGetString(<-line))
+		fmt.Fprint(output, unsafeGetString(<-line))
 	}
+
+	if err, ok := <-readErrors; ok {
+		return err
+	}
+
+	return nil
 }
 
 func validInput(in string, length int) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/Automattic/go-search-replace/searchreplace"
 )
 
 var (
@@ -29,6 +32,125 @@ func doMainTest(t *testing.T, input string, expected string, mainArgs []string) 
 
 	if actual != expected {
 		t.Errorf("%v does not match expected: %v", actual, expected)
+	}
+}
+
+type failingReader struct {
+	value        string
+	err          error
+	read         bool
+	errWithValue bool
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, r.err
+	}
+
+	r.read = true
+	n := copy(p, r.value)
+	if r.errWithValue {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func testReplacements() []*searchreplace.Replacement {
+	return []*searchreplace.Replacement{
+		{
+			From: []byte("http://uss-enterprise.com"),
+			To:   []byte("https://ncc-1701-d.space"),
+		},
+	}
+}
+
+func TestRunReturnsNonZeroOnReadError(t *testing.T) {
+	readError := errors.New("stdin read failed")
+	stdin := &failingReader{
+		value: "Check out: http://uss-enterprise.com/decks/10/sections/forward\n",
+		err:   readError,
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run(stdin, &out, &errOut, testReplacements())
+
+	if code != 1 {
+		t.Errorf("Expected exit code 1, got %d", code)
+	}
+
+	expected := "Check out: https://ncc-1701-d.space/decks/10/sections/forward\n"
+	if out.String() != expected {
+		t.Errorf("%v does not match expected: %v", out.String(), expected)
+	}
+
+	if !strings.Contains(errOut.String(), readError.Error()) {
+		t.Errorf("Expected stderr to contain %q, got %q", readError.Error(), errOut.String())
+	}
+}
+
+func TestRunProcessesPartialLineReturnedWithReadError(t *testing.T) {
+	readError := errors.New("stdin read failed")
+	stdin := &failingReader{
+		value:        "Check out: http://uss-enterprise.com/decks/10/sections/forward",
+		err:          readError,
+		errWithValue: true,
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run(stdin, &out, &errOut, testReplacements())
+
+	if code != 1 {
+		t.Errorf("Expected exit code 1, got %d", code)
+	}
+
+	expected := "Check out: https://ncc-1701-d.space/decks/10/sections/forward"
+	if out.String() != expected {
+		t.Errorf("%v does not match expected: %v", out.String(), expected)
+	}
+
+	if !strings.Contains(errOut.String(), readError.Error()) {
+		t.Errorf("Expected stderr to contain %q, got %q", readError.Error(), errOut.String())
+	}
+}
+
+func TestRunReturnsZeroAtEOF(t *testing.T) {
+	var tests = []struct {
+		testName string
+		in       string
+		out      string
+	}{
+		{
+			testName: "with newline",
+			in:       "Check out: http://uss-enterprise.com/decks/10/sections/forward\n",
+			out:      "Check out: https://ncc-1701-d.space/decks/10/sections/forward\n",
+		},
+		{
+			testName: "without newline",
+			in:       "Check out: http://uss-enterprise.com/decks/10/sections/forward",
+			out:      "Check out: https://ncc-1701-d.space/decks/10/sections/forward",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			code := run(strings.NewReader(test.in), &out, &errOut, testReplacements())
+
+			if code != 0 {
+				t.Errorf("Expected exit code 0, got %d", code)
+			}
+
+			if out.String() != test.out {
+				t.Errorf("%v does not match expected: %v", out.String(), test.out)
+			}
+
+			if errOut.String() != "" {
+				t.Errorf("Expected empty stderr, got %q", errOut.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Propagate non-EOF stdin read errors so the CLI exits nonzero, while still emitting any bytes that were successfully read before the error (including a final line without a trailing newline). Normal EOF remains a success.

Linear: [PLTFRM-2242](https://linear.app/a8c/issue/PLTFRM-2242/silent-error-handling)

## Changes

- Extract the `main` body into two new functions: `run(input, output, errorOutput, replacements) int` (exit-code boundary) and `process(...) error` (I/O loop), so error propagation and exit status can be tested without `os.Exit`.
- Replace direct use of `os.Stdin`/`os.Stdout`/`os.Stderr` inside the processing loop with injected `io.Reader`/`io.Writer`s.
- On every `ReadBytes('\n')`, dispatch the returned bytes for transformation whenever `len(line) > 0`, regardless of whether an error accompanied them. This preserves output for the partial-final-line case and for `(n>0, err!=nil)` reads.
- On a non-`io.EOF` read error, log to stderr and signal a nonzero result via a buffered `readErrors` channel; the outer `run` returns `1` so `main` exits nonzero.
- `io.EOF` continues to terminate the loop silently with exit code `0`.

## Testing and Validation

- `go test ./...` — passes locally.
- `go vet ./...` — clean.
- `git diff --check` — clean.
- New unit tests in [main_test.go](main_test.go):
  - `TestRunReturnsNonZeroOnReadError` — non-EOF error after a successful read: exit `1`, transformed line still written, error surfaced on stderr.
  - `TestRunProcessesPartialLineReturnedWithReadError` — `(n>0, err!=nil)` on the same `Read`: partial line is still transformed and written, exit `1`, stderr carries the error.
  - `TestRunReturnsZeroAtEOF` (table-driven, with/without trailing newline) — EOF path returns exit `0` with empty stderr.

## Review Notes

- Copilot review left one comment claiming a race in `go func(line *[]byte) { ... }(&line)`. [Reply posted](https://github.com/Automattic/go-search-replace/pull/61#discussion_r3266269748) declining the change: `line` is short-declared (`:=`) inside the body of an unconditional `for { ... }`, so each iteration produces a fresh variable; `&line` escapes and Go's escape analysis heap-allocates each iteration's backing independently. The pattern is byte-for-byte identical to `trunk` and predates this PR, so it is also outside the PLTFRM-2242 scope.
- No security, dependency, or public-API changes.

## Risks and Follow-up

- Stdout write errors are still ignored; that path is intentionally out of scope for this change and remains as follow-up.
- Optional cleanup (separate PR): replace the `go func(line *[]byte){...}(&line)` idiom with passing `[]byte` by value to remove the pointer-to-loop-variable pattern entirely.
- No behavior change for the EOF-only path; existing integration tests continue to cover it.
