### PR TITLE
fix: bound input line reads

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func process(input io.Reader, output io.Writer, errorOutput io.Writer, replaceme
 			if err != nil {
 				if err != io.EOF {
 					if errors.Is(err, errInputLineTooLong) {
-						fmt.Fprintf(errorOutput, "%s of %d bytes\n", errInputLineTooLong, maxInputLineSize)
+						fmt.Fprintf(errorOutput, "%s of %d bytes\n", errInputLineTooLong.Error(), maxInputLineSize)
 					} else {
 						fmt.Fprintln(errorOutput, err.Error())
 					}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -19,12 +20,15 @@ const (
 	minInLength  = 4
 	minOutLength = 2
 
+	maxInputLineSize = 16 * 1024 * 1024 // 16 MB
+
 	version = "0.0.11"
 )
 
 var (
-	input = regexp.MustCompile(inputRe)
-	bad   = regexp.MustCompile(badInputRe)
+	input               = regexp.MustCompile(inputRe)
+	bad                 = regexp.MustCompile(badInputRe)
+	errInputLineTooLong = errors.New("input line exceeds maximum size")
 )
 
 func main() {
@@ -97,10 +101,9 @@ func process(input io.Reader, output io.Writer, errorOutput io.Writer, replaceme
 	go func() {
 		defer wg.Done()
 
-		bufferSize := 16 * 1024 * 1024 // 16 MB
-		r := bufio.NewReaderSize(input, bufferSize)
+		r := bufio.NewReaderSize(input, maxInputLineSize)
 		for {
-			line, err := r.ReadBytes('\n')
+			line, err := readLine(r, maxInputLineSize)
 
 			if len(line) > 0 {
 				wg.Add(1)
@@ -116,7 +119,11 @@ func process(input io.Reader, output io.Writer, errorOutput io.Writer, replaceme
 
 			if err != nil {
 				if err != io.EOF {
-					fmt.Fprintln(errorOutput, err.Error())
+					if errors.Is(err, errInputLineTooLong) {
+						fmt.Fprintf(errorOutput, "%s of %d bytes\n", errInputLineTooLong, maxInputLineSize)
+					} else {
+						fmt.Fprintln(errorOutput, err.Error())
+					}
 					readErrors <- err
 				}
 				break
@@ -139,6 +146,27 @@ func process(input io.Reader, output io.Writer, errorOutput io.Writer, replaceme
 	}
 
 	return nil
+}
+
+func readLine(r *bufio.Reader, maxSize int) ([]byte, error) {
+	var line []byte
+
+	for {
+		fragment, err := r.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if len(line)+len(fragment) > maxSize {
+				return nil, errInputLineTooLong
+			}
+
+			line = append(line, fragment...)
+		}
+
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+
+		return line, err
+	}
 }
 
 func validInput(in string, length int) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
+	"io"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -205,6 +207,49 @@ func TestMultipleReplaceWithoutNewlineAtEOF(t *testing.T) {
 	input := "Space, the final frontier!\nCheck out: http://uss-enterprise.com/decks/10/sections/forward"
 	expected := "Space, the final frontier!\nCheck out: warp://ncc-1701-d.space/decks/10/areas/forward"
 	doMainTest(t, input, expected, mainArgs)
+}
+
+func TestInputLineLongerThanLimitFails(t *testing.T) {
+	mainArgs := []string{
+		"http://uss-enterprise.com",
+		"https://ncc-1701-d.space",
+	}
+
+	execArgs := append([]string{"run", basePath}, mainArgs...)
+	cmd := exec.Command("go", execArgs...)
+
+	cmd.Stdin = strings.NewReader(strings.Repeat("x", maxInputLineSize+1))
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected command to fail for an input line over the maximum size")
+	}
+
+	if out.Len() != 0 {
+		t.Errorf("expected no stdout for over-limit input, got %q", out.String())
+	}
+
+	if !strings.Contains(stderr.String(), "input line exceeds maximum size") {
+		t.Errorf("expected line size error, got %q", stderr.String())
+	}
+}
+
+func TestReadLineAcceptsMaximumSize(t *testing.T) {
+	input := strings.Repeat("x", maxInputLineSize)
+	reader := bufio.NewReaderSize(strings.NewReader(input), maxInputLineSize)
+
+	line, err := readLine(reader, maxInputLineSize)
+	if err != io.EOF {
+		t.Fatalf("expected EOF after reading maximum-size line, got %v", err)
+	}
+
+	if len(line) != maxInputLineSize {
+		t.Fatalf("expected line length %d, got %d", maxInputLineSize, len(line))
+	}
 }
 
 func TestSerializedReplaceWithCss(t *testing.T) {


### PR DESCRIPTION
## Summary

Bound CLI input line reads to a 16 MiB maximum to prevent memory exhaustion from malformed or hostile input that contains no newline. Previously, `bufio.Reader.ReadBytes('\n')` would grow its returned slice without an upper bound and could force the process to allocate gigabytes of memory.

Linear: [PLTFRM-2244](https://linear.app/a8c/issue/PLTFRM-2244/unbounded-line-size-memory-exhaustion)

## Changes

- Add `maxInputLineSize` (16 MiB) constant and `errInputLineTooLong` sentinel error in `main.go`.
- Add `readLine` helper wrapping `bufio.Reader.ReadSlice`, which loops past `bufio.ErrBufferFull` while accumulated fragments remain under the limit and returns `errInputLineTooLong` once the limit is exceeded.
- Switch the reader goroutine in `process` to use `readLine` instead of `ReadBytes`, so over-limit input is rejected instead of buffered without bound.
- Report `errInputLineTooLong` to `errorOutput` with the configured byte limit, then signal the error through the existing `readErrors` channel so `process` returns a non-zero status.
- Format the sentinel with `errInputLineTooLong.Error()` for stylistic consistency with the adjacent `err.Error()` branch (no behavioral change — `fmt` already invokes `Error()` for `%s` on values implementing `error`).

No public API change; the `process` signature is unchanged.

## Testing and Validation

- `TestInputLineLongerThanLimitFails` — runs the CLI with `maxInputLineSize+1` bytes and asserts non-zero exit, empty stdout, and the size-limit message on stderr.
- `TestReadLineAcceptsMaximumSize` — feeds exactly `maxInputLineSize` bytes and verifies the full line is returned with `io.EOF`.
- `gofmt -l .` — clean.
- `go vet ./...` — clean.
- `go test -count=1 ./...` — both packages pass.

## Review Notes

- Copilot review flagged the `%s` verb usage on the `errInputLineTooLong` sentinel as producing a `%!s(...)` formatting artifact. The bug premise is incorrect — Go's `fmt` package handles values implementing the `error` interface specially for `%s`/`%v`/`%q` and invokes `Error()`, so stderr output is byte-identical either way.
- The stylistic part of the suggestion (mirror the adjacent `readErr.Error()` branch) was applied in the follow-up `style:` commit. An evidence-based reply was posted on the review thread.

## Risks and Follow-up

- The 16 MiB limit is a hard cap; callers feeding legitimate single-line inputs larger than 16 MiB will now receive a non-zero exit instead of a silent OOM. This matches the security intent of the fix but is a user-visible behavior change for that edge case.
