### PR TITLE
fix: continue after malformed serialized data

### DIFF
--- a/searchreplace/search-replace.go
+++ b/searchreplace/search-replace.go
@@ -37,8 +37,10 @@ func FixLine(line *[]byte, replacements []*Replacement) *[]byte {
 	for len(linePart) > 0 {
 		result, err := fixLineWithSerializedData(linePart, replacements)
 		if err != nil {
-			rebuiltLine = append(rebuiltLine, linePart...)
-			break
+			malformedPart, post := recoverFromSerializedParseError(linePart, replacements)
+			rebuiltLine = append(rebuiltLine, malformedPart...)
+			linePart = post
+			continue
 		}
 		rebuiltLine = append(rebuiltLine, result.Pre...)
 		rebuiltLine = append(rebuiltLine, result.SerializedPortion...)
@@ -58,6 +60,34 @@ func replaceByPart(part []byte, replacements []*Replacement) []byte {
 }
 
 var serializedStringPrefixRegexp = regexp.MustCompile(`s:(\d+):\\"`)
+
+func recoverFromSerializedParseError(linePart []byte, replacements []*Replacement) ([]byte, []byte) {
+	match := serializedStringPrefixRegexp.FindSubmatchIndex(linePart)
+	if match == nil {
+		return replaceByPart(linePart, replacements), []byte{}
+	}
+
+	serializedStart := match[0]
+	contentStart := match[1]
+	resumeIndex := malformedSerializedResumeIndex(linePart, serializedStart, contentStart)
+
+	rebuiltPart := replaceByPart(linePart[:serializedStart], replacements)
+	rebuiltPart = append(rebuiltPart, linePart[serializedStart:resumeIndex]...)
+
+	return rebuiltPart, linePart[resumeIndex:]
+}
+
+func malformedSerializedResumeIndex(linePart []byte, serializedStart int, contentStart int) int {
+	minResumeIndex := serializedStart + 1
+	if contentStart < minResumeIndex {
+		return minResumeIndex
+	}
+	if contentStart > len(linePart) {
+		return len(linePart)
+	}
+
+	return contentStart
+}
 
 func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*SerializedReplaceResult, error) {
 
@@ -148,6 +178,10 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 		currentContentIndex++
 	}
 
+	if nextSliceFound == false {
+		return nil, fmt.Errorf("faulty serialized data: end of serialized data not found")
+	}
+
 	content := append([]byte{}, linePart[contentStartIndex:contentEndIndex+1]...)
 
 	content = replaceByPart(content, replacements)
@@ -156,10 +190,6 @@ func fixLineWithSerializedData(linePart []byte, replacements []*Replacement) (*S
 
 	// and we rebuild the string
 	rebuiltSerializedString := "s:" + strconv.Itoa(contentLength) + ":\\\"" + string(content) + "\\\";"
-
-	if nextSliceFound == false {
-		return nil, fmt.Errorf("faulty serialized data: end of serialized data not found")
-	}
 
 	result := SerializedReplaceResult{
 		Pre:               pre,
@@ -222,7 +252,7 @@ func unescapeContent(escaped []byte) []byte {
 
 	for index < len(escaped) {
 
-		if escaped[index] == backslash {
+		if escaped[index] == backslash && index+1 < len(escaped) {
 			unescapedBytePair := getUnescapedBytesIfEscaped(escaped[index : index+2])
 			byteLength := len(unescapedBytePair)
 

--- a/searchreplace/search-replace_test.go
+++ b/searchreplace/search-replace_test.go
@@ -131,19 +131,96 @@ func TestReplace(t *testing.T) {
 			in:  []byte(`('s:21:\"http://automattic.com\";'),('s:21:\"https://a8c.com\";')`),
 			out: []byte(`('s:22:\"https://automattic.com\";'),('s:21:\"https://a8c.com\";')`),
 		},
-		//TODO: Test disabled. This is a really hard problem to solve.
-		// Generally recovering from a 'syntax error' of a parser - which is what we have here, due to the wrong byte size for a8c.com,
-		// is probably impossible. It destroys all offsets and suddenly we lose track of where the tokenization is at.
-		// Self-recovery is prone to error, and might grab the token entrance at the wrong place.
-		//{
-		//	testName: "only fix updated strings, with bad data in between",
-		//
-		//	from: []byte("http://automattic.com"),
-		//	to:   []byte("https://automattic.com"),
-		//
-		//	in:  []byte(`('s:21:\"http://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:21:\"http://automattic.com\";')`),
-		//	out: []byte(`('s:22:\"https://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:22:\"https://automattic.com\";')`),
-		//},
+		{
+			testName: "malformed serialized string with close delimiter before ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:999:\"http://automattic.com\"; http://automattic.com`),
+			out: []byte(`s:999:\"https://automattic.com\"; https://automattic.com`),
+		},
+		{
+			testName: "malformed serialized string before delimiter-like ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`('s:999:\"broken'),('http://automattic.com\";'),('http://automattic.com')`),
+			out: []byte(`('s:999:\"broken'),('https://automattic.com\";'),('https://automattic.com')`),
+		},
+		{
+			testName: "malformed serialized string between valid serialized strings",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`('s:21:\"http://automattic.com\";'),('s:999:\"http://automattic.com\";'),('s:21:\"http://automattic.com\";')`),
+			out: []byte(`('s:22:\"https://automattic.com\";'),('s:999:\"https://automattic.com\";'),('s:22:\"https://automattic.com\";')`),
+		},
+		{
+			testName: "unterminated malformed serialized candidate before valid serialized string",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:999:\"http://automattic.com s:21:\"http://automattic.com\";`),
+			out: []byte(`s:999:\"https://automattic.com s:22:\"https://automattic.com\";`),
+		},
+		{
+			testName: "unterminated malformed serialized candidate before ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:999:\"http://automattic.com and then http://automattic.com`),
+			out: []byte(`s:999:\"https://automattic.com and then https://automattic.com`),
+		},
+		{
+			testName: "overflowing serialized length before valid serialized string",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:999999999999999999999999999999:\"http://automattic.com s:21:\"http://automattic.com\";`),
+			out: []byte(`s:999999999999999999999999999999:\"https://automattic.com s:22:\"https://automattic.com\";`),
+		},
+		{
+			testName: "truncated escaped serialized prefix after ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`before http://automattic.com s:1:\"`),
+			out: []byte(`before https://automattic.com s:1:\"`),
+		},
+		{
+			testName: "malformed serialized content with zero length before ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:0:\"\\\"; http://automattic.com`),
+			out: []byte(`s:0:\"\\\"; https://automattic.com`),
+		},
+		{
+			testName: "serialized content ending with lone backslash before ordinary text",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`s:1:\"\\"; http://automattic.com`),
+			out: []byte(`s:1:\"\\"; https://automattic.com`),
+		},
+		{
+			testName: "only fix updated strings with bad data in between",
+
+			from: []byte("http://automattic.com"),
+			to:   []byte("https://automattic.com"),
+
+			in:  []byte(`('s:21:\"http://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:21:\"http://automattic.com\";')`),
+			out: []byte(`('s:22:\"https://automattic.com\";'),('s:21:\"https://a8c.com\";'),('s:22:\"https://automattic.com\";')`),
+		},
 		{
 			testName: "emoji from",
 


### PR DESCRIPTION
## Summary

This PR implements fail-open behavior for malformed serialized fragments during search-replace processing so that a single parse error does not stop replacements for the rest of the line.

It addresses [PLTFRM-2246](https://linear.app/a8c/issue/PLTFRM-2246/fail-open-behavior-after-serialized-parse-error) by preserving malformed serialized content in place when parsing is unsafe, while continuing to scan and process subsequent segments.

## Changes

- Updated serialized-data handling to continue processing after malformed serialized fragments instead of aborting line processing.
- Added explicit handling for missing serialized closing delimiters.
- Hardened unescape handling for trailing lone backslashes.
- Added regression coverage for:
  - malformed serialized payloads,
  - unterminated serialized segments,
  - overflow-length payloads,
  - mixed valid and invalid serialized segments in the same line.

## Testing and Validation

- `go test -count=1 ./...` passed.
- `go vet ./...` completed cleanly.

## Review Notes

- Commit history has been normalized to repository conventions (Conventional Commit subject plus structured body).
- No PR review threads are currently present.
- PR state is open and awaiting review (`REVIEW_REQUIRED`).
