### PR TITLE
fix: `semver-major-days` not supported by `githiub-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14


### PR DESCRIPTION
This pull request updates the Dependabot configuration by removing the unsupported `semver-major-days` for the `github-actions` ecosystem.

Ref: https://github.com/Automattic/go-search-replace/runs/78754888087